### PR TITLE
remove unused t from tele_var_t and tele_array_t

### DIFF
--- a/src/teletype.h
+++ b/src/teletype.h
@@ -56,7 +56,6 @@ typedef struct {
 	const char *name;
 	void (*func)(uint8_t);
 	int16_t v;
-	tele_word_t t;
 } tele_var_t;
 
 typedef struct {
@@ -68,7 +67,6 @@ typedef struct {
 	const char *name;
 	int16_t v[4];
 	void (*func)(uint8_t);
-	tele_word_t t[4];
 } tele_array_t;
 
 typedef struct {


### PR DESCRIPTION
I managed to get [flycheck][] working with properly with emacs and avr32, anyway it's flagged a few things... in particular a bunch of uninitialized fields.

So, as far as I can tell the field `t` is not used in `tele_var_t` and `tele_array_t`, I'm guessing it's left over from some previous use?

I haven't tested this change on hardware...

[flycheck]: http://www.flycheck.org/