### PR TITLE
Cleanup teletype dep on avr.

### DIFF
--- a/src/teletype.c
+++ b/src/teletype.c
@@ -14,7 +14,6 @@
 #ifdef SIM
 #define DBG printf("%s", dbg);
 #else
-#include "print_funcs.h"
 #define DBG print_dbg(dbg);
 #endif
 


### PR DESCRIPTION
Can we do without this include?

`print_funcs.h` pulls in a bunch of avr bits that are not needed/wanted when running teletype off the device.

cc  @samdoshi @tehn