### PR TITLE
Teletype Docs UX Enhancements

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -20,3 +20,19 @@ trim_trailing_whitespace = true
 indent_style = space
 indent_size = 4
 trim_trailing_whitespace = true
+
+# CSS
+[*.css]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+trim_trailing_whitespace = true
+
+# HTML
+[*.html]
+indent_style = space
+indent_size = 4
+tab_width = 4
+end_of_line = lf
+trim_trailing_whitespace = true

--- a/docs/modes.md
+++ b/docs/modes.md
@@ -66,8 +66,8 @@ In most cases, the clipboard is shared between _live_, _edit_ and the 2 _preset_
 
 The pattern mode clipboard is independent of text and code clipboard.
 
-| Key                 | Action                                                                                |
-|---------------------|---------------------------------------------------------------------------------------|
+| Key                 | Action                                          |
+|---------------------|-------------------------------------------------|
 | `<down>`            | move down                                                                             |
 | `alt-<down>`        | move a page down                                                                      |
 | `<up>`              | move up                                                                               |

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -170,7 +170,8 @@ def main():
                             "--self-contained",
                             "--toc",
                             "--toc-depth=2",
-                            "--css=" + str(TEMPLATE_DIR / "docs.css")])
+                            "--css=" + str(TEMPLATE_DIR / "docs.css"),
+                            "--template=" + str(TEMPLATE_DIR / "template.html5")])
         elif ext == ".pdf" or ext == ".tex":
             latex_preamble = env.get_template("latex_preamble.jinja2.md")
             latex = latex_preamble.render(fonts_dir=FONTS_DIR) + "\n\n"

--- a/utils/templates/docs.css
+++ b/utils/templates/docs.css
@@ -51,6 +51,21 @@ body {
     max-width: 800px;
     margin: 0 auto;
 }
+
+.CopyLink {
+    font-size: 12px;
+    font-weight: 400;
+    margin-left: 10px;
+    display: none;
+}
+
+h1:hover .CopyLink,
+h2:hover .CopyLink,
+h3:hover .CopyLink,
+h4:hover .CopyLink {
+    display: inline;
+}
+
 a {
     color: #4183C4;
 }
@@ -79,6 +94,9 @@ h6 {
     -webkit-font-smoothing: antialiased;
     cursor: text;
     position: relative;
+    display: flex;
+    align-items: center;
+    cursor: pointer;
 }
 h1:hover a.anchor,
 h2:hover a.anchor,

--- a/utils/templates/docs.css
+++ b/utils/templates/docs.css
@@ -2,16 +2,30 @@ body {
     font-family: Helvetica, arial, sans-serif;
     font-size: 14px;
     line-height: 1.6;
-    padding-top: 10px;
-    padding-bottom: 10px;
     background-color: white;
-    padding: 30px;
+    display: flex;
+    margin: 0;
+    height: 100vh;
 }
-body > *:first-child {
-    margin-top: 0 !important;
+
+#TOC {
+    width: 30%;
+    height: 100%;
+    overflow-y: scroll;
 }
-body > *:last-child {
-    margin-bottom: 0 !important;
+
+.content {
+    width: calc(70% - 40px);
+    padding: 0 20px;
+    height: 100%;
+    overflow-y: scroll;
+    max-width: 100%;
+    overflow-x: hidden;
+}
+.content-inner {
+    width: 100%;
+    max-width: 800px;
+    margin: 0 auto;
 }
 a {
     color: #4183C4;

--- a/utils/templates/docs.css
+++ b/utils/templates/docs.css
@@ -4,23 +4,47 @@ body {
     line-height: 1.6;
     background-color: white;
     display: flex;
+    flex-wrap: wrap;
     margin: 0;
     height: 100vh;
 }
 
+.NavBar {
+    width: 100%;
+    background: #848992;
+    color: #fff;
+    padding: 10px;
+    display: flex;
+    text-transform: uppercase;
+    align-items: center;
+    cursor: pointer;
+    position: fixed;
+}
+
+.NavBar .Icon {
+    height: 15px;
+    width: 15px;
+    fill: #fff;
+    margin-right: 20px;
+    margin-top: -2px;
+}
+
 #TOC {
-    width: 30%;
-    height: 100%;
+    width: 250px;
+    height: calc(100% - 62px);
     overflow-y: scroll;
+    padding: 10px;
+    margin-top: 42px;
 }
 
 .content {
-    width: calc(70% - 40px);
     padding: 0 20px;
-    height: 100%;
+    height: calc(100% - 62px);
     overflow-y: scroll;
     max-width: 100%;
     overflow-x: hidden;
+    flex: 1;
+    margin-top: 42px;
 }
 .content-inner {
     width: 100%;

--- a/utils/templates/docs.css
+++ b/utils/templates/docs.css
@@ -243,6 +243,8 @@ blockquote >:last-child {
 }
 table {
     padding: 0;
+    width: 100%;
+    table-layout: fixed;
 }
 table tr {
     border-top: 1px solid #cccccc;
@@ -259,6 +261,7 @@ table tr th {
     text-align: left;
     margin: 0;
     padding: 6px 13px;
+    word-break: break-word;
 }
 table tr td {
     border: 1px solid #cccccc;
@@ -356,10 +359,12 @@ tt {
     font-family: Menlo, Consolas, monospace;
     margin: 0 2px;
     padding: 0 5px;
-    white-space: nowrap;
     border: 1px solid #eaeaea;
     background-color: #f8f8f8;
     border-radius: 3px;
+    white-space: pre-wrap;
+    word-break: break-word;
+    overflow-x: scroll;
 }
 pre code {
     margin: 0;

--- a/utils/templates/docs.css
+++ b/utils/templates/docs.css
@@ -382,7 +382,7 @@ tt {
     border-radius: 3px;
     white-space: pre-wrap;
     word-break: break-word;
-    overflow-x: scroll;
+    overflow-x: auto;
 }
 pre code {
     margin: 0;

--- a/utils/templates/op_table.jinja2.md
+++ b/utils/templates/op_table.jinja2.md
@@ -4,8 +4,8 @@ make sure that the description column is long!
 Pandoc uses the size of the header column to calculate the absolute column widths
 (as Latex requires explict column sizes)
 -->
-| OP                     | OP _(set)_   | _(aliases)_ | Description                      |
-|------------------------|--------------|-------------|----------------------------------|
+| OP                       | OP _(set)_         | _(aliases)_ | Description              |
+|----------------------|--------------------|---------|----------------------------------|
 {% for op in ops %}
 | **`{{ op.prototype }}`** | {% if op.prototype_set is defined %}**`{{ op.prototype_set }}`**{% endif %} | {% for a in op.aliases %} **`{{a}}`** {% if not loop.last %}, {% endif %} {% endfor %} | {{ op.short | replace("\n", " ") }} |
 {% endfor %}

--- a/utils/templates/template.html5
+++ b/utils/templates/template.html5
@@ -95,7 +95,13 @@ $endif$
 
     navBar.onclick = toggleNavBar;
 
-    var hidden = true;
+    var hidden;
+
+    if (window.innerWidth < 700) {
+        hidden = false;
+    } else {
+        hidden = true;
+    }
     toggleNavBar();
 </script>
 <div class="content">

--- a/utils/templates/template.html5
+++ b/utils/templates/template.html5
@@ -1,0 +1,71 @@
+<!DOCTYPE html>
+<html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
+<head>
+  <meta charset="utf-8">
+  <meta name="generator" content="pandoc">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
+$for(author-meta)$
+  <meta name="author" content="$author-meta$">
+$endfor$
+$if(date-meta)$
+  <meta name="dcterms.date" content="$date-meta$">
+$endif$
+$if(keywords)$
+  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
+$endif$
+  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+  <style type="text/css">code{white-space: pre;}</style>
+$if(quotes)$
+  <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+$endif$
+$if(highlighting-css)$
+  <style type="text/css">
+$highlighting-css$
+  </style>
+$endif$
+$for(css)$
+  <link rel="stylesheet" href="$css$">
+$endfor$
+$if(math)$
+  $math$
+$endif$
+  <!--[if lt IE 9]>
+    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
+  <![endif]-->
+$for(header-includes)$
+  $header-includes$
+$endfor$
+</head>
+<body>
+$for(include-before)$
+$include-before$
+$endfor$
+$if(title)$
+<header>
+<h1 class="title">$title$</h1>
+$if(subtitle)$
+<p class="subtitle">$subtitle$</p>
+$endif$
+$for(author)$
+<p class="author">$author$</p>
+$endfor$
+$if(date)$
+<p class="date">$date$</p>
+$endif$
+</header>
+$endif$
+$if(toc)$
+<nav id="$idprefix$TOC">
+$toc$
+</nav>
+$endif$
+<div class="content">
+<div class="content-inner">
+$body$
+$for(include-after)$
+$include-after$
+$endfor$
+</div>
+</div>
+</body>
+</html>

--- a/utils/templates/template.html5
+++ b/utils/templates/template.html5
@@ -120,5 +120,44 @@ $endfor$
             val.setAttribute("target", "_blank");
         }
     });
+
+    // Make headers clickable and copy link to section
+    [].forEach.call(document.querySelectorAll('h1,h2,h3,h4'), val => {
+        // see: https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
+        function copyTextToClipboard(text) {
+            var textArea = document.createElement("textarea");
+            textArea.style.position = 'fixed';
+            textArea.style.top = 0;
+            textArea.style.left = 0;
+            textArea.style.width = '2em';
+            textArea.style.height = '2em';
+            textArea.style.padding = 0;
+            textArea.style.border = 'none';
+            textArea.style.outline = 'none';
+            textArea.style.boxShadow = 'none';
+            textArea.style.background = 'transparent';
+            textArea.value = text;
+            document.body.appendChild(textArea);
+            textArea.select();
+            document.execCommand('copy');
+            document.body.removeChild(textArea);
+        }
+
+        var newElem = document.createElement("span");
+        newElem.classList.add("CopyLink");
+        newElem.innerHTML = "Copy link to clipboard";
+        val.appendChild(newElem);
+
+        val.addEventListener('click', function(event) {
+            var fullLink = window.location.origin + window.location.pathname +
+                "#" + val.getAttribute("id");
+            copyTextToClipboard(fullLink);
+            newElem.innerHTML = "Copied!";
+        });
+
+        val.addEventListener('mouseout', function(event) {
+            newElem.innerHTML = "Copy link to clipboard";
+        });
+    });
 </script>
 </html>

--- a/utils/templates/template.html5
+++ b/utils/templates/template.html5
@@ -1,163 +1,191 @@
 <!DOCTYPE html>
 <html$if(lang)$ lang="$lang$"$endif$$if(dir)$ dir="$dir$"$endif$>
-<head>
-  <meta charset="utf-8">
-  <meta name="generator" content="pandoc">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
-$for(author-meta)$
-  <meta name="author" content="$author-meta$">
-$endfor$
-$if(date-meta)$
-  <meta name="dcterms.date" content="$date-meta$">
-$endif$
-$if(keywords)$
-  <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
-$endif$
-  <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
-  <style type="text/css">code{white-space: pre;}</style>
-$if(quotes)$
-  <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
-$endif$
-$if(highlighting-css)$
-  <style type="text/css">
-$highlighting-css$
-  </style>
-$endif$
-$for(css)$
-  <link rel="stylesheet" href="$css$">
-$endfor$
-$if(math)$
-  $math$
-$endif$
-  <!--[if lt IE 9]>
-    <script src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js"></script>
-  <![endif]-->
-$for(header-includes)$
-  $header-includes$
-$endfor$
-</head>
-<body>
-$for(include-before)$
-$include-before$
-$endfor$
-$if(title)$
-<header>
-<h1 class="title">$title$</h1>
-$if(subtitle)$
-<p class="subtitle">$subtitle$</p>
-$endif$
-$for(author)$
-<p class="author">$author$</p>
-$endfor$
-$if(date)$
-<p class="date">$date$</p>
-$endif$
-</header>
-</div>
-$endif$
-<svg style="display: none;">
-    <symbol id="custom-hamburger-icon" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1664 1344v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45z"/></symbol>
-    <symbol id="custom-close-icon" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z"/></symbol>
-</svg>
-<div class="NavBar" id="NavBar">
-<svg class="Icon Icon--open Icon--hide" id="NavBar-openIcon">
-    <use xlink:href="#custom-hamburger-icon"></use>
-</svg>
-<svg class="Icon Icon--close Icon--hide" id="NavBar-closeIcon">
-	<use xlink:href="#custom-close-icon"></use>
-</svg>
-Table of Contents
-</div>
-$if(toc)$
-<nav id="$idprefix$TOC">
-$toc$
-</nav>
-$endif$
-<script>
-    var navBar = document.getElementById("NavBar"),
-        navOpenIcon = document.getElementById("NavBar-openIcon"),
-        navCloseIcon = document.getElementById("NavBar-closeIcon"),
-        TOC = document.getElementById("TOC");
+    <head>
+        <meta charset="utf-8">
+        <meta name="generator" content="pandoc">
+        <meta name="viewport" content="width=device-width, initial-scale=1.0, user-scalable=yes">
 
-    toggleNavBar = function() {
-        if (hidden) {
-            navCloseIcon.style.display = 'block';
-            navOpenIcon.style.display = 'none';
-            TOC.style.display = 'block';
-        } else {
-            navCloseIcon.style.display = 'none';
-            navOpenIcon.style.display = 'block';
-            TOC.style.display = 'none';
-        }
+        $for(author-meta)$
+            <meta name="author" content="$author-meta$">
+        $endfor$
 
-        hidden = !hidden;
-    }
+        $if(date-meta)$
+            <meta name="dcterms.date" content="$date-meta$">
+        $endif$
 
-    navBar.onclick = toggleNavBar;
+        $if(keywords)$
+            <meta name="keywords" content="$for(keywords)$$keywords$$sep$, $endfor$">
+        $endif$
 
-    var hidden;
+        <title>$if(title-prefix)$$title-prefix$ – $endif$$pagetitle$</title>
+        <style type="text/css">code{white-space: pre;}</style>
 
-    if (window.innerWidth < 700) {
-        hidden = false;
-    } else {
-        hidden = true;
-    }
-    toggleNavBar();
-</script>
-<div class="content">
-<div class="content-inner">
-$body$
-$for(include-after)$
-$include-after$
-$endfor$
-</div>
-</div>
-</body>
-<script>
-    // All non-internal links should open new tab/window
-    [].forEach.call(document.getElementsByTagName("a"), val => {
-        if (val.getAttribute("href").charAt(0) !== '#') {
-            val.setAttribute("target", "_blank");
-        }
-    });
+        $if(quotes)$
+            <style type="text/css">q { quotes: "“" "”" "‘" "’"; }</style>
+        $endif$
 
-    // Make headers clickable and copy link to section
-    [].forEach.call(document.querySelectorAll('h1,h2,h3,h4'), val => {
-        // see: https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
-        function copyTextToClipboard(text) {
-            var textArea = document.createElement("textarea");
-            textArea.style.position = 'fixed';
-            textArea.style.top = 0;
-            textArea.style.left = 0;
-            textArea.style.width = '2em';
-            textArea.style.height = '2em';
-            textArea.style.padding = 0;
-            textArea.style.border = 'none';
-            textArea.style.outline = 'none';
-            textArea.style.boxShadow = 'none';
-            textArea.style.background = 'transparent';
-            textArea.value = text;
-            document.body.appendChild(textArea);
-            textArea.select();
-            document.execCommand('copy');
-            document.body.removeChild(textArea);
-        }
+        $if(highlighting-css)$
+            <style type="text/css">
+                $highlighting-css$
+            </style>
+        $endif$
 
-        var newElem = document.createElement("span");
-        newElem.classList.add("CopyLink");
-        newElem.innerHTML = "Copy link to clipboard";
-        val.appendChild(newElem);
+        $for(css)$
+            <link rel="stylesheet" href="$css$">
+        $endfor$
 
-        val.addEventListener('click', function(event) {
-            var fullLink = window.location.origin + window.location.pathname +
-                "#" + val.getAttribute("id");
-            copyTextToClipboard(fullLink);
-            newElem.innerHTML = "Copied!";
+        $if(math)$
+            $math$
+        $endif$
+
+        <!--[if lt IE 9]>
+            <script
+                src="//cdnjs.cloudflare.com/ajax/libs/html5shiv/3.7.3/html5shiv-printshiv.min.js">
+            </script>
+        <![endif]-->
+
+        $for(header-includes)$
+            $header-includes$
+        $endfor$
+    </head>
+    <body>
+        $for(include-before)$
+            $include-before$
+        $endfor$
+
+        $if(title)$
+            <header>
+                <h1 class="title">$title$</h1>
+
+                $if(subtitle)$
+                    <p class="subtitle">$subtitle$</p>
+                $endif$
+
+                $for(author)$
+                    <p class="author">$author$</p>
+                $endfor$
+
+                $if(date)$
+                    <p class="date">$date$</p>
+                $endif$
+            </header>
+        $endif$
+
+        <svg style="display: none;">
+            <symbol id="custom-hamburger-icon" viewBox="0 0 1792 1792"
+                xmlns="http://www.w3.org/2000/svg">
+                    <path d="M1664 1344v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45z"/>
+            </symbol>
+            <symbol id="custom-close-icon" viewBox="0 0 1792 1792"
+                xmlns="http://www.w3.org/2000/svg">
+                    <path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z"/>
+            </symbol>
+        </svg>
+
+        <div class="NavBar" id="NavBar">
+            <svg class="Icon Icon--open Icon--hide" id="NavBar-openIcon">
+                <use xlink:href="#custom-hamburger-icon"></use>
+            </svg>
+            <svg class="Icon Icon--close Icon--hide" id="NavBar-closeIcon">
+                <use xlink:href="#custom-close-icon"></use>
+            </svg>
+
+            Table of Contents
+        </div>
+
+        $if(toc)$
+            <nav id="$idprefix$TOC">
+                $toc$
+            </nav>
+        $endif$
+
+        <script>
+            var navBar = document.getElementById("NavBar"),
+                navOpenIcon = document.getElementById("NavBar-openIcon"),
+                navCloseIcon = document.getElementById("NavBar-closeIcon"),
+                TOC = document.getElementById("TOC");
+
+            toggleNavBar = function() {
+                if (hidden) {
+                    navCloseIcon.style.display = 'block';
+                    navOpenIcon.style.display = 'none';
+                    TOC.style.display = 'block';
+                } else {
+                    navCloseIcon.style.display = 'none';
+                    navOpenIcon.style.display = 'block';
+                    TOC.style.display = 'none';
+                }
+                hidden = !hidden;
+            }
+
+            navBar.onclick = toggleNavBar;
+
+            var hidden;
+
+            if (window.innerWidth < 700) {
+                hidden = false;
+            } else {
+                hidden = true;
+            }
+
+            toggleNavBar();
+        </script>
+        <div class="content">
+            <div class="content-inner">
+                $body$
+
+                $for(include-after)$
+                    $include-after$
+                $endfor$
+
+            </div>
+        </div>
+    </body>
+    <script>
+        // All non-internal links should open new tab/window
+        [].forEach.call(document.getElementsByTagName("a"), val => {
+            if (val.getAttribute("href").charAt(0) !== '#') {
+                val.setAttribute("target", "_blank");
+            }
         });
 
-        val.addEventListener('mouseout', function(event) {
+        // Make headers clickable and copy link to section
+        [].forEach.call(document.querySelectorAll('h1,h2,h3,h4'), val => {
+            // see: https://stackoverflow.com/questions/400212/how-do-i-copy-to-the-clipboard-in-javascript
+            function copyTextToClipboard(text) {
+                var textArea = document.createElement("textarea");
+                textArea.style.position = 'fixed';
+                textArea.style.top = 0;
+                textArea.style.left = 0;
+                textArea.style.width = '2em';
+                textArea.style.height = '2em';
+                textArea.style.padding = 0;
+                textArea.style.border = 'none';
+                textArea.style.outline = 'none';
+                textArea.style.boxShadow = 'none';
+                textArea.style.background = 'transparent';
+                textArea.value = text;
+                document.body.appendChild(textArea);
+                textArea.select();
+                document.execCommand('copy');
+                document.body.removeChild(textArea);
+            }
+
+            var newElem = document.createElement("span");
+            newElem.classList.add("CopyLink");
             newElem.innerHTML = "Copy link to clipboard";
+            val.appendChild(newElem);
+
+            val.addEventListener('click', function(event) {
+                var fullLink = window.location.origin + window.location.pathname +
+                    "#" + val.getAttribute("id");
+                copyTextToClipboard(fullLink);
+                newElem.innerHTML = "Copied!";
+            });
+
+            val.addEventListener('mouseout', function(event) {
+                newElem.innerHTML = "Copy link to clipboard";
+            });
         });
-    });
-</script>
+    </script>
 </html>

--- a/utils/templates/template.html5
+++ b/utils/templates/template.html5
@@ -113,4 +113,12 @@ $endfor$
 </div>
 </div>
 </body>
+<script>
+    // All non-internal links should open new tab/window
+    [].forEach.call(document.getElementsByTagName("a"), val => {
+        if (val.getAttribute("href").charAt(0) !== '#') {
+            val.setAttribute("target", "_blank");
+        }
+    });
+</script>
 </html>

--- a/utils/templates/template.html5
+++ b/utils/templates/template.html5
@@ -53,12 +53,51 @@ $if(date)$
 <p class="date">$date$</p>
 $endif$
 </header>
+</div>
 $endif$
+<svg style="display: none;">
+    <symbol id="custom-hamburger-icon" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1664 1344v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45zm0-512v128q0 26-19 45t-45 19h-1408q-26 0-45-19t-19-45v-128q0-26 19-45t45-19h1408q26 0 45 19t19 45z"/></symbol>
+    <symbol id="custom-close-icon" viewBox="0 0 1792 1792" xmlns="http://www.w3.org/2000/svg"><path d="M1490 1322q0 40-28 68l-136 136q-28 28-68 28t-68-28l-294-294-294 294q-28 28-68 28t-68-28l-136-136q-28-28-28-68t28-68l294-294-294-294q-28-28-28-68t28-68l136-136q28-28 68-28t68 28l294 294 294-294q28-28 68-28t68 28l136 136q28 28 28 68t-28 68l-294 294 294 294q28 28 28 68z"/></symbol>
+</svg>
+<div class="NavBar" id="NavBar">
+<svg class="Icon Icon--open Icon--hide" id="NavBar-openIcon">
+    <use xlink:href="#custom-hamburger-icon"></use>
+</svg>
+<svg class="Icon Icon--close Icon--hide" id="NavBar-closeIcon">
+	<use xlink:href="#custom-close-icon"></use>
+</svg>
+Table of Contents
+</div>
 $if(toc)$
 <nav id="$idprefix$TOC">
 $toc$
 </nav>
 $endif$
+<script>
+    var navBar = document.getElementById("NavBar"),
+        navOpenIcon = document.getElementById("NavBar-openIcon"),
+        navCloseIcon = document.getElementById("NavBar-closeIcon"),
+        TOC = document.getElementById("TOC");
+
+    toggleNavBar = function() {
+        if (hidden) {
+            navCloseIcon.style.display = 'block';
+            navOpenIcon.style.display = 'none';
+            TOC.style.display = 'block';
+        } else {
+            navCloseIcon.style.display = 'none';
+            navOpenIcon.style.display = 'block';
+            TOC.style.display = 'none';
+        }
+
+        hidden = !hidden;
+    }
+
+    navBar.onclick = toggleNavBar;
+
+    var hidden = true;
+    toggleNavBar();
+</script>
 <div class="content">
 <div class="content-inner">
 $body$


### PR DESCRIPTION
Not ready for merge!

This PR makes some UX enhancements to the pandoc generated HTML5 Teletype docs.
---
Things fixed in this PR:
- [x] stick TOC on left hand side of window
    - [x] for mobile, hide behind hamburger icon
- [x] better responsiveness of wide tables (see Variables table in OPs and MODs section
    - currently, wide tables overflow the horizontal width of smaller screens.
    - **I’ve updated things to fill better across screen sizes. The tables are still not great, but they are usable.**
- [x] `target=“_blank”` on links off of docs
    - In past projects I’ve worked on, we’ve decided that links outside of the content you are currently looking at should open in a new tab so as to prevent context switching.
- [x] anchor link next to doc sections (allowing for linking of specific sections of the docs)
    - this shouldn’t be difficult because it’s already reflected in the URL as a hash
- [x] Update .editorconfig
- [x] Update h1 and h3-in-code-element css weirdness that got added
---
Things I didn't get to.
- Quantization scale content is repeated
    - It’s fine that it’s repeated visually, need to see if the content is repeated in the repo…could lead to change drift
- Include footnote sources under relevant sections (rather than at the bottom of the docs)
    - Not a big deal…if this isn’t a 5-minute fix, I’ll probably push this one out.
- Explore the ability to export each section to it’s own .HTML file (not sure if that’s possible).
- Enhancements to TOC
    - make full width (and click-link-to-close) for more narrow browser widths
    - highlight when hovering over a particular nav element in the TOC.