### PR TITLE
Fixes #35 by guarding SCENE from initial I script

### DIFF
--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -96,6 +96,7 @@ description = """
 Load scene `x` (0-31).
 
 Does _not_ execute the `I` script.
+Will _not_ execute from the `I` script on scene load.  Will execute on subsequent calls to the `I` script.
 
 **WARNING**: You will lose any unsaved changes to your scene.
 """

--- a/module/main.c
+++ b/module/main.c
@@ -736,6 +736,7 @@ int main(void) {
     delay_ms(50);
 
     run_script(&scene_state, INIT_SCRIPT);
+    scene_state.initializing = false;
 
     while (true) { check_events(); }
 }

--- a/module/preset_r_mode.c
+++ b/module/preset_r_mode.c
@@ -99,7 +99,9 @@ void do_preset_read() {
     flash_update_last_saved_scene(preset_select);
     ss_set_scene(&scene_state, preset_select);
 
+    scene_state.initializing = true;
     run_script(&scene_state, INIT_SCRIPT);
+    scene_state.initializing = false;
 
     set_last_mode();
 }

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -105,8 +105,10 @@ static void op_SCENE_get(const void *NOTUSED(data), scene_state_t *ss,
 static void op_SCENE_set(const void *NOTUSED(data), scene_state_t *ss,
                          exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t scene = cs_pop(cs);
-    ss->variables.scene = scene;
-    tele_scene(scene);
+    if (!ss->initializing) {
+        ss->variables.scene = scene;
+        tele_scene(scene);
+    }
 }
 
 static void op_SCRIPT_get(const void *NOTUSED(data), scene_state_t *ss,

--- a/src/state.c
+++ b/src/state.c
@@ -11,6 +11,7 @@
 // scene init
 
 void ss_init(scene_state_t *ss) {
+    ss->initializing = true;
     ss_variables_init(ss);
     ss_patterns_init(ss);
     ss->delay.count = 0;

--- a/src/state.h
+++ b/src/state.h
@@ -94,6 +94,7 @@ typedef struct {
 } scene_script_t;
 
 typedef struct {
+    bool initializing;
     scene_variables_t variables;
     scene_pattern_t patterns[PATTERN_COUNT];
     scene_delay_t delay;


### PR DESCRIPTION
Added an initialization flag to the scene state to denote when a scene
is first loading.  SCENE operator aborts if the flag is present.