### PR TITLE
Fixes #10: LAST reports script run time deltas

### DIFF
--- a/docs/ops/variables.toml
+++ b/docs/ops/variables.toml
@@ -126,6 +126,21 @@ prototype = "TIME.ACT"
 prototype_set = "TIME.ACT x"
 short = "enable or disable timer counting, default `1`"
 
+[LAST]
+prototype = "LAST"
+short = "get value in milliseconds since last script run time"
+description = '''
+Gets the number of milliseconds since the current script was run.  From the live mode, shows time elapsed since last run of I script.
+
+For example, one-line tap tempo:
+
+```
+M LAST
+```
+
+Running this script twice will set the metronome to be the time between runs.
+'''
+
 [X]
 prototype = "X"
 prototype_set = "X x"

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -37,6 +37,7 @@
         "T"           => { MATCH_OP(E_OP_T); };
         "TIME"        => { MATCH_OP(E_OP_TIME); };
         "TIME.ACT"    => { MATCH_OP(E_OP_TIME_ACT); };
+        "LAST"        => { MATCH_OP(E_OP_LAST); };
         "X"           => { MATCH_OP(E_OP_X); };
         "Y"           => { MATCH_OP(E_OP_Y); };
         "Z"           => { MATCH_OP(E_OP_Z); };

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -32,7 +32,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     // variables
     &op_A, &op_B, &op_C, &op_D, &op_DRUNK, &op_DRUNK_MAX, &op_DRUNK_MIN,
     &op_DRUNK_WRAP, &op_FLIP, &op_I, &op_O, &op_O_INC, &op_O_MAX, &op_O_MIN,
-    &op_O_WRAP, &op_T, &op_TIME, &op_TIME_ACT, &op_X, &op_Y, &op_Z,
+    &op_O_WRAP, &op_T, &op_TIME, &op_TIME_ACT, &op_LAST, &op_X, &op_Y, &op_Z,
 
     // metronome
     &op_M, &op_M_SYM_EXCLAMATION, &op_M_ACT, &op_M_RESET,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -24,6 +24,7 @@ typedef enum {
     E_OP_T,
     E_OP_TIME,
     E_OP_TIME_ACT,
+    E_OP_LAST,
     E_OP_X,
     E_OP_Y,
     E_OP_Z,

--- a/src/ops/variables.c
+++ b/src/ops/variables.c
@@ -6,6 +6,8 @@
 #include "ops/op.h"
 
 
+static void op_LAST_get(const void *data, scene_state_t *ss, exec_state_t *es,
+                         command_state_t *cs);
 static void op_DRUNK_get(const void *data, scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs);
 static void op_DRUNK_set(const void *data, scene_state_t *ss, exec_state_t *es,
@@ -35,6 +37,7 @@ const tele_op_t op_O_WRAP     = MAKE_SIMPLE_VARIABLE_OP(O.WRAP    , variables.o_
 const tele_op_t op_T          = MAKE_SIMPLE_VARIABLE_OP(T         , variables.t         );
 const tele_op_t op_TIME       = MAKE_SIMPLE_VARIABLE_OP(TIME      , variables.time      );
 const tele_op_t op_TIME_ACT   = MAKE_SIMPLE_VARIABLE_OP(TIME.ACT  , variables.time_act  );
+const tele_op_t op_LAST       =             MAKE_GET_OP(LAST  , op_LAST_get, 0, true);
 const tele_op_t op_X          = MAKE_SIMPLE_VARIABLE_OP(X         , variables.x         );
 const tele_op_t op_Y          = MAKE_SIMPLE_VARIABLE_OP(Y         , variables.y         );
 const tele_op_t op_Z          = MAKE_SIMPLE_VARIABLE_OP(Z         , variables.z         );
@@ -44,7 +47,12 @@ const tele_op_t op_FLIP  = MAKE_GET_SET_OP(FLIP , op_FLIP_get , op_FLIP_set , 0,
 const tele_op_t op_O     = MAKE_GET_SET_OP(O    , op_O_get    , op_O_set    , 0, true);
 // clang-format on
 
-
+static void op_LAST_get(const void *NOTUSED(data), scene_state_t *ss,
+                        exec_state_t *es, command_state_t *cs) {
+    int16_t last = ss_get_script_last(ss, es->script_number);
+    cs_push(cs, last);
+}
+        
 static void op_DRUNK_get(const void *NOTUSED(data), scene_state_t *ss,
                          exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t min = ss->variables.drunk_min;

--- a/src/ops/variables.h
+++ b/src/ops/variables.h
@@ -21,6 +21,7 @@ extern const tele_op_t op_O_WRAP;
 extern const tele_op_t op_T;
 extern const tele_op_t op_TIME;
 extern const tele_op_t op_TIME_ACT;
+extern const tele_op_t op_LAST;
 extern const tele_op_t op_X;
 extern const tele_op_t op_Y;
 extern const tele_op_t op_Z;

--- a/src/state.c
+++ b/src/state.c
@@ -234,6 +234,17 @@ size_t ss_scripts_size() {
     return sizeof(scene_script_t) * SCRIPT_COUNT;
 }
 
+int16_t ss_get_script_last(scene_state_t *ss, size_t idx) {
+    int16_t now = ss->variables.time;
+    int16_t last = ss->scripts[idx].last_time;
+    if (now < last) 
+        return (INT16_MAX - last) + (now - INT16_MIN); // I must be dense? 
+    return now - last;
+}
+
+void ss_update_script_last(scene_state_t *ss, size_t idx) {
+    ss->scripts[idx].last_time = ss->variables.time;
+}
 
 ////////////////////////////////////////////////////////////////////////////////
 // EXEC STATE //////////////////////////////////////////////////////////////////
@@ -241,6 +252,7 @@ size_t ss_scripts_size() {
 void es_init(exec_state_t *es) {
     es->if_else_condition = true;
     es->exec_depth = 0;
+    es->script_number = INIT_SCRIPT;
 }
 
 

--- a/src/state.h
+++ b/src/state.h
@@ -91,6 +91,7 @@ typedef struct {
 typedef struct {
     uint8_t l;
     tele_command_t c[SCRIPT_MAX_COMMANDS];
+    int16_t last_time;
 } scene_script_t;
 
 typedef struct {
@@ -145,6 +146,8 @@ void ss_delete_script_command(scene_state_t *ss, size_t script_idx,
 
 scene_script_t *ss_scripts_ptr(scene_state_t *ss);
 size_t ss_scripts_size(void);
+int16_t ss_get_script_last(scene_state_t *ss, size_t idx);
+void ss_update_script_last(scene_state_t *ss, size_t idx);
 
 ////////////////////////////////////////////////////////////////////////////////
 // EXEC STATE //////////////////////////////////////////////////////////////////
@@ -153,6 +156,7 @@ size_t ss_scripts_size(void);
 typedef struct {
     bool if_else_condition;
     uint8_t exec_depth;
+    uint16_t script_number;
 } exec_state_t;
 
 extern void es_init(exec_state_t *es);

--- a/src/teletype.c
+++ b/src/teletype.c
@@ -141,6 +141,7 @@ process_result_t run_script_with_exec_state(scene_state_t *ss, exec_state_t *es,
                                             size_t script_no) {
     process_result_t result = {.has_value = false, .value = 0 };
 
+    es->script_number = script_no;
     // increase the execution depth on each call (e.g. from SCRIPT)
     es->exec_depth++;
     // only allow the depth to reach 8
@@ -155,7 +156,7 @@ process_result_t run_script_with_exec_state(scene_state_t *ss, exec_state_t *es,
 
     // decrease the depth once the commands have been run
     es->exec_depth--;
-
+    ss_update_script_last(ss, script_no);
     return result;
 }
 


### PR DESCRIPTION
Now tracking script number in the execution state and script last run
times in the script state.  Executing LAST from the live input reports
the time since the INIT script was run.

One line tap tempo (hit F1 twice):
1: M LAST
M: TR.P 1