### PR TITLE
Add a PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,9 @@
+#### What does this PR do?
+
+#### Link to [lines](https://llllllll.co/) tag or thread about the features in this PR.
+
+#### How should this be manually tested?
+
+#### Any background context you want to provide?
+
+#### If the related Github issues aren't referenced in your commits, please link to them here.

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,9 +1,13 @@
 #### What does this PR do?
 
-#### Link to [lines](https://llllllll.co/) tag or thread about the features in this PR.
+#### Provide links to any related discussion on [lines](https://llllllll.co/).
 
 #### How should this be manually tested?
 
 #### Any background context you want to provide?
 
 #### If the related Github issues aren't referenced in your commits, please link to them here.
+
+#### I have,
+* [ ] updated CHANGELOG.md
+* [ ] updated the documentation


### PR DESCRIPTION
Github provides the ability to load pull request templates when a new PR is submitted. The template lives in either the `.github` or `docs` directory. To keep `docs` clean, I created a `.github` directory and added the template there. The PR template aligns with the discussion organization effort on lines.

More information on Github support [here](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/).

Here's this PR using the template,

#### What does this PR do?
Github provides the ability to load pull request templates when a new PR is submitted. The template lives in either the `.github` or `docs` directory. To keep `docs` clean, I created a `.github` directory and added the template there. 

More information on Github support [here](https://help.github.com/articles/creating-a-pull-request-template-for-your-repository/).

#### Link to [lines](https://llllllll.co/) tag or thread about the features in this PR.

#### How should this be manually tested?

#### Any background context you want to provide?
The PR template aligns with the discussion organization effort on lines.

#### If the related Github issues aren't referenced in your commits, please link to them here.
