### PR TITLE
New Issue Template

### DIFF
--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 #### Please describe the bug.
 
-#### What release of the firmware are you using? Please include the hash displayed at startup and the release of the software.
+#### Please include the hash displayed at startup and the release of the software (e.g. "Teletype v2.0.1 5f838c9")
 
 #### What steps are required to reproduce the bug?
 1. step 1

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,0 +1,8 @@
+#### Please describe the bug.
+
+#### What version of the firmware are you using?
+
+#### What steps are required to reproduce the bug?
+1. step 1
+1. step 2
+1. step 3

--- a/.github/ISSUE_TEMPLATE.md
+++ b/.github/ISSUE_TEMPLATE.md
@@ -1,6 +1,6 @@
 #### Please describe the bug.
 
-#### What version of the firmware are you using?
+#### What release of the firmware are you using? Please include the hash displayed at startup and the release of the software.
 
 #### What steps are required to reproduce the bug?
 1. step 1

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -1,0 +1,13 @@
+#### What does this PR do?
+
+#### Provide links to any related discussion on [lines](https://llllllll.co/).
+
+#### How should this be manually tested?
+
+#### Any background context you want to provide?
+
+#### If the related Github issues aren't referenced in your commits, please link to them here.
+
+#### I have,
+* [ ] updated CHANGELOG.md
+* [ ] updated the documentation


### PR DESCRIPTION
#### What does this PR do?
Adds a template for new Github issues.

#### Provide links to any related discussion on [lines](https://llllllll.co/).
It was suggested in this [PR](https://github.com/monome/teletype/pull/103) by @samdoshi 

#### How should this be manually tested?
Only way to test it is to merge it. I've checked the markdown formatting in Atom Github-flavor markdown preview and it worked ok.

#### Any background context you want to provide?
I'm concerned this is too heavy weight and might intimidate new issue writers. The PR is editable by maintainers, so I'd suggest making edits directly rather than waiting for me to edit it based on feedback. Think of this PR as an initial draft to get thoughts going.

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [ ] updated CHANGELOG.md
* [ ] updated the documentation
