### PR TITLE
programatically grab version for docs and live mode

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -8,8 +8,5 @@ Teletype is a dynamic, musical event triggering platform.
 &mdash; [PDF scene recall sheet](https://monome.org/docs/modular/teletype/TT_scene_RECALL_sheet.pdf)
 &mdash; [Default scenes](http://monome.org/docs/modular/teletype/scenes-1.0/)
 
-* Current version: 2.1.0 
+* Current version: _VERSION_
 &mdash; [Firmware update procedure](https://monome.org/docs/modular/update/)
-
-
-

--- a/module/Makefile
+++ b/module/Makefile
@@ -79,4 +79,4 @@ include $(MAKEFILE_PATH)
 
 # Add the git commit id to a file for use when printing out the version
 ../module/gitversion.c: ../.git/HEAD ../.git/index
-	echo "const char *git_version = \"$(shell git describe --always --dirty | tr '[a-z]' '[A-Z]')\";" > $@
+	echo "const char *git_version = \"$(shell cut -d '-' -f 1 <<< $(shell git describe --tags | cut -c 2-)) $(shell git describe --always --dirty | tr '[a-z]' '[A-Z]')\";" > $@

--- a/module/live_mode.c
+++ b/module/live_mode.c
@@ -213,7 +213,7 @@ uint8_t screen_refresh_live() {
             output.has_value = false;
         }
         else if (show_welcome_message) {
-            strcpy(s, "TELETYPE: ");
+            strcpy(s, "TELETYPE ");
             strncat(s, git_version, 35 - strlen(s));
             show_welcome_message = false;
         }

--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -8,7 +8,7 @@ import jinja2
 import pypandoc
 import pytoml as toml
 
-from common import validate_toml
+from common import validate_toml, get_tt_version
 
 if (sys.version_info.major, sys.version_info.minor) < (3, 6):
     raise Exception("need Python 3.6 or later")
@@ -19,6 +19,9 @@ TEMPLATE_DIR = ROOT_DIR / "utils" / "templates"
 DOCS_DIR = ROOT_DIR / "docs"
 OP_DOCS_DIR = DOCS_DIR / "ops"
 FONTS_DIR = ROOT_DIR / "utils" / "fonts"
+_VERSION_ = get_tt_version()
+_VERSION_STR_ = "Teletype " + \
+              _VERSION_["tag"] + " " + _VERSION_["hash"] + " Cheatsheet"
 
 
 # We want to run inject_latex in parallel as it's quite slow, and we must run
@@ -78,7 +81,7 @@ def cheatsheet_tex():
     print(f"Using ops docs directory: {OP_DOCS_DIR}")
     print()
 
-    output = ""
+    output = _VERSION_STR_ + "\n\n"
     for (section, title, new_page) in OPS_SECTIONS:
         toml_file = Path(OP_DOCS_DIR, section + ".toml")
         if toml_file.exists() and toml_file.is_file():

--- a/utils/common/__init__.py
+++ b/utils/common/__init__.py
@@ -1,5 +1,6 @@
 from os import path
 import re
+import subprocess
 
 _THIS_FILE = path.realpath(__file__)
 _THIS_DIR = path.dirname(_THIS_FILE)
@@ -105,3 +106,12 @@ def validate_toml(ops):
         for k in keys - {"prototype", "prototype_set", "aliases",
                          "short", "description"}:
             print(f" - WARNING: {name} - unknown entry - {k}")
+
+
+def get_tt_version():
+    tag = subprocess.check_output(["git", "describe", "--tags"]) \
+                    .decode("utf-8").split("-")[0]
+    hash = subprocess.check_output(["git", "describe",
+                                    "--always", "--dirty"]) \
+                     .decode("utf-8")[:-1].upper()
+    return {'tag': tag, 'hash': hash}

--- a/utils/templates/latex_preamble.jinja2.md
+++ b/utils/templates/latex_preamble.jinja2.md
@@ -1,5 +1,5 @@
 ---
-title: Teletype Documentation
+title: {{title}}
 documentclass: report
 geometry: margin=1in
 links-as-notes: true


### PR DESCRIPTION
This does a few things:
- remove hardcoded references to version in both c code and docs md
- updates module make command that gets git version to use the tag to grab the current semantic teletype version
- updates live mode prompt to use the updated version string (same formatting--user won't notice any changes)
- updates both docs (html/pdf) and cheatsheet to include version in the title.

---

I didn't run clang, but the c changes are so small I can't imagine a formatting issue snuck in.

I conformed to pep8 using flake8 for all the python code.  @samdoshi There seems to be a few `f"..."` strings that were getting picked up as invalid syntax from running flake8 on the commandline as well as with the atom package I downloaded...I didn't edit them, didn't see any error output when running the docs make commands, and couldn't not figure out what it thought was invalid about the syntax.  Let me know if there's something I can do to get those to go away.

I'm mostly happy with the code, but the makefile gitversion.c command is really long, and I am not bash-savvy enough to figure how to cleanly break up into multiple lines.  If anyone has any suggestions there, paste what it should be and I'll gladly change it!

---

What it looks like on HTML docs:

<img width="885" alt="screen shot 2017-10-13 at 8 05 51 pm" src="https://user-images.githubusercontent.com/1342624/31570918-d698f766-b057-11e7-8d0e-0021e61bd780.png">

On pdf docs:

<img width="753" alt="screen shot 2017-10-13 at 8 06 05 pm" src="https://user-images.githubusercontent.com/1342624/31570920-dc1399f8-b057-11e7-84dc-0a4bb556aabe.png">

<img width="708" alt="screen shot 2017-10-13 at 8 06 11 pm" src="https://user-images.githubusercontent.com/1342624/31570922-dea35ae6-b057-11e7-98bd-b98c0cd4d2dd.png">

On pdf cheatsheet:

<img width="364" alt="screen shot 2017-10-13 at 8 07 58 pm" src="https://user-images.githubusercontent.com/1342624/31570925-e471a040-b057-11e7-9f22-c05da370a27a.png">

Running on teletype:

![img_1670](https://user-images.githubusercontent.com/1342624/31570926-ec53ddc8-b057-11e7-8cb5-f0d466e2aba5.JPG)