### PR TITLE
Fixes #120 by updating only dirty lines

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNEXT
 - **NEW**: added a cheat sheet PDF
+- **IMP**: screen now redraws only lines that have changed
 
 ## v2.1
 - **BREAKING**: the `I` variable is now scoped to the `L` loop, and does not exist outside of an execution context.  Scripts using `I` as a general-purpose variable will be broken. 

--- a/module/edit_mode.c
+++ b/module/edit_mode.c
@@ -42,6 +42,7 @@ void set_edit_mode() {
 void set_edit_mode_script(uint8_t new_script) {
     script = new_script;
     if (script >= SCRIPT_COUNT) script = SCRIPT_COUNT - 1;
+    dirty = D_ALL;
 }
 
 void process_edit_keys(uint8_t k, uint8_t m, bool is_held_key) {
@@ -176,8 +177,8 @@ void screen_mutes_updated() {
     dirty |= D_INPUT;
 }
 
-bool screen_refresh_edit() {
-    bool screen_dirty = false;
+uint8_t screen_refresh_edit() {
+    uint8_t screen_dirty = 0;
 
     if (dirty & D_INPUT) {
         char prefix = script + '1';
@@ -192,7 +193,7 @@ bool screen_refresh_edit() {
             char shaded[2] = { prefix, '\0' };
             font_string_region_clip(&line[7], shaded, 0, 0, 0x4, 0);
         }
-        screen_dirty = true;
+        screen_dirty |= (1 << 7);
         dirty &= ~D_INPUT;
     }
 
@@ -215,7 +216,7 @@ bool screen_refresh_edit() {
         region_fill(&line[6], 0);
         font_string_region_clip(&line[6], s, 0, 0, 0x4, 0);
 
-        screen_dirty = true;
+        screen_dirty |= (1 << 6);
         dirty &= ~D_MESSAGE;
     }
 
@@ -233,7 +234,7 @@ bool screen_refresh_edit() {
             }
         }
 
-        screen_dirty = true;
+        screen_dirty |= 0x3F;
         dirty &= ~D_LIST;
     }
 

--- a/module/edit_mode.h
+++ b/module/edit_mode.h
@@ -8,6 +8,6 @@ void set_edit_mode(void);
 void set_edit_mode_script(uint8_t new_script);
 void process_edit_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
 void screen_mutes_updated(void);
-bool screen_refresh_edit(void);
+uint8_t screen_refresh_edit(void);
 
 #endif

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -289,8 +289,8 @@ void process_help_keys(uint8_t k, uint8_t m, bool is_held_key) {
     }
 }
 
-bool screen_refresh_help() {
-    if (!dirty) { return false; }
+uint8_t screen_refresh_help() {
+    if (!dirty) { return 0; }
 
     // clamp value of page_no
     if (page_no >= HELP_PAGES) page_no = HELP_PAGES - 1;
@@ -306,5 +306,5 @@ bool screen_refresh_help() {
     }
 
     dirty = false;
-    return true;
+    return 0xFF;
 };

--- a/module/help_mode.h
+++ b/module/help_mode.h
@@ -6,6 +6,6 @@
 
 void set_help_mode(void);
 void process_help_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
-bool screen_refresh_help(void);
+uint8_t screen_refresh_help(void);
 
 #endif

--- a/module/live_mode.c
+++ b/module/live_mode.c
@@ -171,11 +171,11 @@ void process_live_keys(uint8_t k, uint8_t m, bool is_held_key) {
 }
 
 
-bool screen_refresh_live() {
-    bool screen_dirty = false;
+uint8_t screen_refresh_live() {
+    uint8_t screen_dirty = 0;
     if (dirty & D_INPUT) {
         line_editor_draw(&le, '>', &line[7]);
-        screen_dirty = true;
+        screen_dirty |= (1 << 7);
         dirty &= ~D_INPUT;
     }
 
@@ -207,14 +207,14 @@ bool screen_refresh_live() {
         region_fill(&line[6], 0);
         font_string_region_clip(&line[6], s, 0, 0, 0x4, 0);
 
-        screen_dirty = true;
+        screen_dirty |= (1 << 6);
         dirty &= ~D_MESSAGE;
     }
 
     if (dirty & D_LIST) {
         for (int i = 0; i < 6; i++) region_fill(&line[i], 0);
 
-        screen_dirty = true;
+        screen_dirty |= 0x3E;
         dirty &= ~D_LIST;
     }
 
@@ -288,7 +288,7 @@ bool screen_refresh_live() {
         }
 
         activity_prev = activity;
-        screen_dirty = true;
+        screen_dirty |= 0x1;
         activity &= ~A_MUTES;
     }
 

--- a/module/live_mode.h
+++ b/module/live_mode.h
@@ -9,6 +9,6 @@ void set_metro_icon(bool display);
 void init_live_mode(void);
 void set_live_mode(void);
 void process_live_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
-bool screen_refresh_live(void);
+uint8_t screen_refresh_live(void);
 
 #endif

--- a/module/main.c
+++ b/module/main.c
@@ -341,7 +341,7 @@ void handler_Trigger(int32_t data) {
 }
 
 void handler_ScreenRefresh(int32_t data) {
-    bool screen_dirty = false;
+    uint8_t screen_dirty = 0;
 
     switch (mode) {
         case M_PATTERN: screen_dirty = screen_refresh_pattern(); break;
@@ -352,9 +352,8 @@ void handler_ScreenRefresh(int32_t data) {
         case M_EDIT: screen_dirty = screen_refresh_edit(); break;
     }
 
-    if (screen_dirty) {
-        for (size_t i = 0; i < 8; i++) { region_draw(&line[i]); }
-    }
+    for (size_t i = 0; i < 8; i++) 
+        if (screen_dirty & (1 << i)) { region_draw(&line[i]); }
 }
 
 void handler_EventTimer(int32_t data) {

--- a/module/pattern_mode.c
+++ b/module/pattern_mode.c
@@ -393,9 +393,9 @@ void process_pattern_knob(uint16_t knob, uint8_t m) {
     }
 }
 
-bool screen_refresh_pattern() {
-    if (!dirty) { return false; }
-
+uint8_t screen_refresh_pattern() {
+    if (!dirty) { return 0; }
+    
     char s[32];
     for (uint8_t y = 0; y < 8; y++) {
         region_fill(&line[y], 0);
@@ -464,5 +464,5 @@ bool screen_refresh_pattern() {
 
     dirty = false;
 
-    return true;
+    return 0xFF;
 }

--- a/module/pattern_mode.h
+++ b/module/pattern_mode.h
@@ -7,6 +7,6 @@
 void set_pattern_mode(void);
 void process_pattern_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
 void process_pattern_knob(uint16_t knob, uint8_t mod_key);
-bool screen_refresh_pattern(void);
+uint8_t screen_refresh_pattern(void);
 
 #endif

--- a/module/preset_r_mode.c
+++ b/module/preset_r_mode.c
@@ -72,8 +72,8 @@ void process_preset_r_keys(uint8_t k, uint8_t m, bool is_held_key) {
     }
 }
 
-bool screen_refresh_preset_r() {
-    if (!dirty) { return false; }
+uint8_t screen_refresh_preset_r() {
+    if (!dirty) { return 0; }
 
     char s[32];
     itoa(preset_select, s, 10);
@@ -91,7 +91,7 @@ bool screen_refresh_preset_r() {
     }
 
     dirty = false;
-    return true;
+    return 0xFF;
 };
 
 void do_preset_read() {

--- a/module/preset_r_mode.h
+++ b/module/preset_r_mode.h
@@ -8,6 +8,6 @@ void set_preset_r_mode(uint16_t knob);
 void process_preset_r_knob(uint16_t knob, uint8_t mod_key);
 void process_preset_r_long_front(void);
 void process_preset_r_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
-bool screen_refresh_preset_r(void);
+uint8_t screen_refresh_preset_r(void);
 
 #endif

--- a/module/preset_w_mode.c
+++ b/module/preset_w_mode.c
@@ -105,9 +105,10 @@ void process_preset_w_keys(uint8_t k, uint8_t m, bool is_held_key) {
 }
 
 
-bool screen_refresh_preset_w() {
-    if (!(dirty & D_ALL)) { return false; }
+uint8_t screen_refresh_preset_w() {
+    if (!(dirty & D_ALL)) { return 0; }
 
+    uint8_t screen_dirty = 0;
     if (dirty & D_LIST) {
         char header[6] = ">>> ";
         itoa(preset_select, header + 4, 10);
@@ -122,12 +123,14 @@ bool screen_refresh_preset_w() {
                                     2, 0, 0xa + a * 5, a);
         }
         dirty &= ~D_LIST;
+        screen_dirty |= 0x7F;
     }
 
     if (dirty & D_INPUT) {
         line_editor_draw(&le, '+', &line[7]);
         dirty &= ~D_INPUT;
+        screen_dirty |= (1 << 7);
     }
 
-    return true;
+    return screen_dirty;
 }

--- a/module/preset_w_mode.h
+++ b/module/preset_w_mode.h
@@ -6,6 +6,6 @@
 
 void set_preset_w_mode(void);
 void process_preset_w_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
-bool screen_refresh_preset_w(void);
+uint8_t screen_refresh_preset_w(void);
 
 #endif


### PR DESCRIPTION
#### What does this PR do?

Refactors refresh routines to indicate which lines they have dirtied, which are then selectively redrawn.

#### How should this be manually tested?

Use all the modes and ensure that all lines are always redrawn when they need to be.

#### Any background context you want to provide?

Reducing calls to the display hardware will improve system performance.

The tracker will need a refactor to leverage per-line redrawing.

#### I have,
* [x] updated CHANGELOG.md
* [na] updated the documentation
