### PR TITLE
JI op corrected to map to volt/octave values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## vNEXT
 - **NEW**: added a cheat sheet PDF
+- **FIX** : corrected functionality of JI op for 1volt/octave tuning
 
 ## v2.1
 - **BREAKING**: the `I` variable is now scoped to the `L` loop, and does not exist outside of an execution context.  Scripts using `I` as a general-purpose variable will be broken. 


### PR DESCRIPTION
#### What does this PR do?
Corrects the functionality of the JI op. It previously gave raw ratio conversions that didn't relate to the 1volt / octave standard in Eurorack.

Uses a prime-factorization technique, which goes up to 13-limit tuning. Should be sufficient for most musical use-cases. Every extra prime extends worst case search time for invalid ratios.

Presently an invalid ratio (one which cannot be factored with primes of
13 or less) simply returns 0 (the base pitch). All results are scaled
between 0 and V 1.

The weird list of constants is calculated with a logarithmic function, representing some kind of musical fraction of the octave. These constants can simply be composed with addition (numerator) and subtraction (denominator) to find the JI result. Prime factorization is used to break down composite input into it's prime components.

#### How should this be manually tested?
I tried to add these tests in process_tests.c but they would always fail. Any ideas how? I can push those tests too if I can figure out why they didn't work
"JI 0 0" -> 0
"JI 3 2" -> 958
"JI 1323 -1024" -> 605
"JI -40 39" -> 60
"JI 23 13" -> 0

#### If the related Github issues aren't referenced in your commits, please link to them here.
https://github.com/monome/teletype/issues/129

#### I have,
* [x] updated CHANGELOG.md
* [ ] updated the documentation
No changes to documentation required.

I also wrote a little script that generates the constants stored in the function. I would normally include them in a block comment immediately above the function, but it didn't seem to fit with the style. Is there somewhere more comments or info are stored about the code?

Here's the function for reference:
int16_t ji_find_prime_constant( uint16_t prime )
{
	float r = 1638.0 * logf( (float)prime ) / log( 2.0 );
	while( r > 1638.0 ){ r -= 1638.0; }
	r *= 16.0;
	return( (int16_t)( r + 0.5 ) );
}
