### PR TITLE
Fixes #140 by copying I to child exec state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## v2.NEXT
+- **FIX**: I now accessible to child SCRIPTS
+
 ## v2.2
 - **NEW**: added a cheat sheet PDF
 - **NEW**: new bitwise ops: &, |, ^, ~, BSET, BCLR, BGET

--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -41,6 +41,17 @@ If `x` is not zero execute command
                        (see example 2)
     ```
 
+  5. Dependent scripts
+
+    ```text
+    SCRIPT 1:
+    IF 0: TR.P 1    => do nothing
+    SCRIPT 2        => will pulse output 2
+
+    SCRIPT 2:
+    ELSE: TR.P 2    => will not pulse output 2 if called directly,
+                       but will if called from script 1
+    ```
 """
 
 [ELIF]

--- a/src/state.c
+++ b/src/state.c
@@ -434,8 +434,16 @@ size_t es_push(exec_state_t *es) {
         es->variables[es->exec_depth].delayed = false;
         es->variables[es->exec_depth].while_depth = 0;
         es->variables[es->exec_depth].while_continue = false;
-        es->variables[es->exec_depth].if_else_condition = true;
-        es->variables[es->exec_depth].i = 0;
+        if (es->exec_depth > 0) {
+            es->variables[es->exec_depth].if_else_condition =
+                es->variables[es->exec_depth - 1].if_else_condition;
+            es->variables[es->exec_depth].i = 
+                es->variables[es->exec_depth - 1].i;
+        }
+        else {
+            es->variables[es->exec_depth].if_else_condition = true;
+            es->variables[es->exec_depth].i = 0;
+        }
         es->variables[es->exec_depth].breaking = false;
         es->exec_depth += 1;  // exec_depth = 1 at the root
     }


### PR DESCRIPTION
#### What does this PR do?
Propagates I values to child exec states (SCRIPT calls)
Does the same for IF condition state

#### Provide links to any related discussion on [lines](https://llllllll.co/).
https://llllllll.co/t/teletype-asynchronous-tasks-and-variable-scope/11611

#### How should this be manually tested?
```
1: L 1 4: SCRIPT 2
2: TR.P I
```

All 4 triggers should fire.

```
1: IF 0: BRK
    SCRIPT 2
2: ELSE: TR.P 1
```
Trigger 1 should fire.

#### Any background context you want to provide?

Changes in 2.1 to L / I / IF to fix bugs with concurrency limited I's scope to an execution context.  Copying I forward through execution depths is desirable so that scripts can use I to know where the parent loop is.

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [*] updated CHANGELOG.md
* [*] updated the documentation
