### PR TITLE
Fixes a SEGFAULT I get when running the tests after compiling with clang

### DIFF
--- a/src/chaos.h
+++ b/src/chaos.h
@@ -1,5 +1,5 @@
 #ifndef CHAOS_H
-#define CHOAS_H
+#define CHAOS_H
 #include <stdint.h>
 
 typedef enum {

--- a/tests/op_mod_tests.c
+++ b/tests/op_mod_tests.c
@@ -35,8 +35,8 @@ TEST op_stack_size() {
         const tele_op_t *op = tele_ops[i];
 
         if (op->get != NULL) {
-            scene_state_t ss = {};  // initalise to empty
-                                    // (needs dedicated initaliser)
+            scene_state_t ss;
+            ss_init(&ss);
             exec_state_t es;
             es_init(&es);
             es_push(&es);
@@ -63,10 +63,11 @@ TEST op_stack_size() {
         }
 
         if (op->set != NULL) {
-            scene_state_t ss = {};  // initalise to empty
-                                    // (needs dedicated initaliser)
+            scene_state_t ss;
+            ss_init(&ss);
             exec_state_t es;
             es_init(&es);
+            es_push(&es);
             command_state_t cs;
             cs_init(&cs);
 
@@ -93,10 +94,11 @@ TEST mod_stack_size() {
     for (size_t i = 0; i < E_MOD__LENGTH; i++) {
         const tele_mod_t *mod = tele_mods[i];
 
-        scene_state_t ss = {};  // initalise to empty
-                                // (needs dedicated initaliser)
+        scene_state_t ss;
+        ss_init(&ss);
         exec_state_t es;
         es_init(&es);
+        es_push(&es);
         command_state_t cs;
         cs_init(&cs);
 


### PR DESCRIPTION
#### What does this PR do?

1. Fixes a typo in a `#define` in `src/chaos.h`
2. Fixes a SEGFAULT I get when running the tests after compiling with clang.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

N/A

#### How should this be manually tested?

1. Compile as normal and ensure tests continue to pass.
2. Compile with clang and ensure tests continue to pass.

#### Any background context you want to provide?

Here's what I was getting before this change:

```
$ lldb -e tests/tests
(lldb) target create "tests/tests"
Current executable set to 'tests/tests' (x86_64).
(lldb) run
Process 14328 launched: '/Users/mroberts/src/personal/teletype/tests/tests' (x86_64)

* Suite match_token_suite:
..
2 tests - 2 passed, 0 failed, 0 skipped (132 ticks, 0.000 sec)

* Suite op_mod_suite:
...tests was compiled with optimization - stepping may behave oddly; variables may not be available.
Process 14328 stopped
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x7fff0d47b344)
    frame #0: 0x0000000100006b84 tests`every_set_skip(e=0x00007fff0d47b340, skip=false) at every.c:9 [opt]
   6   	}
   7   	
   8   	void every_set_skip(every_count_t *e, bool skip) {
-> 9   	    e->skip = skip;
   10  	}
   11  	
   12  	void every_set_count(every_count_t *e, int16_t count) {
Target 0: (tests) stopped.
(lldb) bt
* thread #1, queue = 'com.apple.main-thread', stop reason = EXC_BAD_ACCESS (code=1, address=0x7fff0d47b344)
  * frame #0: 0x0000000100006b84 tests`every_set_skip(e=0x00007fff0d47b340, skip=false) at every.c:9 [opt]
    frame #1: 0x0000000100017bd8 tests`mod_EVERY_func(ss=0x00007ffeefbf99b8, es=0x00007ffeefbf9910, cs=<unavailable>, post_command=0x000000010001f1f8) at controlflow.c:165 [opt]
    frame #2: 0x0000000100002827 tests`op_mod_suite at op_mod_tests.c:114 [opt]
    frame #3: 0x000000010000270b tests`op_mod_suite at op_mod_tests.c:126 [opt]
    frame #4: 0x000000010000194a tests`greatest_run_suite(suite_cb=(tests`op_mod_suite at op_mod_tests.c:122), suite_name="op_mod_suite") at main.c:37 [opt]
    frame #5: 0x0000000100001562 tests`main(argc=1, argv=0x00007ffeefbfceb8) at main.c:43 [opt]
    frame #6: 0x00007fff50dda015 libdyld.dylib`start + 1
    frame #7: 0x00007fff50dda015 libdyld.dylib`start + 1
(lldb) ^D
```

I'm pretty sure this is because of the way `scene_state_t` and similar structs were being initialized in the `mod_stack_size` test (using `{}` or nothing at all, rather than `ss_init` and related functions). I'm not actually sure if, e.g., `es_push` is needed, but I included it anyway.

#### If the related Github issues aren't referenced in your commits, please link to them here.

N/A

#### I have,
* [ ] updated CHANGELOG.md
* [ ] updated the documentation
