### PR TITLE
Simulator & tests depend on src/ops/wslash.o

### DIFF
--- a/simulator/Makefile
+++ b/simulator/Makefile
@@ -10,7 +10,7 @@ OBJ = tt.o ../src/teletype.o ../src/command.o ../src/helpers.o \
 	../src/ops/metronome.o ../src/ops/maths.o ../src/ops/orca.o \
 	../src/ops/patterns.o ../src/ops/queue.o ../src/ops/stack.o \
 	../src/ops/telex.o ../src/ops/variables.o  ../src/ops/whitewhale.o \
-	../src/ops/init.o \
+	../src/ops/wslash.o ../src/ops/init.o \
 	../libavr32/src/euclidean/euclidean.o ../libavr32/src/euclidean/data.o \
 	../libavr32/src/util.o
 

--- a/tests/Makefile
+++ b/tests/Makefile
@@ -15,7 +15,7 @@ tests: main.o \
 	../src/ops/metronome.o ../src/ops/maths.o ../src/ops/orca.o \
 	../src/ops/patterns.o ../src/ops/queue.o ../src/ops/stack.o \
 	../src/ops/telex.o ../src/ops/variables.o  ../src/ops/whitewhale.c \
-	../src/ops/turtle.o ../src/ops/init.o \
+	../src/ops/wslash.o ../src/ops/turtle.o ../src/ops/init.o \
 	../libavr32/src/euclidean/data.o ../libavr32/src/euclidean/euclidean.o \
 	../libavr32/src/util.o
 	$(CC) -o $@ $^ $(CFLAGS)


### PR DESCRIPTION
#### What does this PR do?

This PR fixes up the build. https://github.com/monome/teletype/pull/152 introduced W/ ops, but we need to update `simulator/Makefile` and `tests/Makefile` to depend on the new object, `src/ops/wslash.o`.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

N/A

#### How should this be manually tested?

* Check Travis
* Build manually

#### Any background context you want to provide?

N/A

#### If the related Github issues aren't referenced in your commits, please link to them here.

N/A

#### I have,
* [ ] updated CHANGELOG.md
* [ ] updated the documentation
