### PR TITLE
DEVICE.FLIP

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v3.x
 
+- **NEW**: new op: DEVICE.FLIP
 - **FIX**: [some keyboards losing keystrokes](https://github.com/monome/teletype/issues/156)
 
 ## v3.0

--- a/docs/ops/hardware.toml
+++ b/docs/ops/hardware.toml
@@ -159,3 +159,10 @@ description = """
 Read the current state of trigger input `x` (0=low, 1=high). 
 """
 
+["DEVICE.FLIP"]
+prototype = "DEVICE.FLIP"
+short = "Flip the screen/inputs/outputs"
+description = """
+Flip the screen, the inputs and the outputs. This op is useful if you want to mount your Teletype upside down.
+The new state will be saved to flash. 
+"""

--- a/module/flash.c
+++ b/module/flash.c
@@ -61,8 +61,9 @@ void flash_prepare() {
 
     cal_data_t cal = { 0, 16383, 0, 16383 };
     flashc_memcpy((void *)&f.cal, &cal, sizeof(cal), true);
-    device_config_t device_config = { .flip = 0 };
-    flashc_memcpy((void *)&f.device_config, &device_config, sizeof(device_config), true);
+    device_config_t device_config = {.flip = 0 };
+    flashc_memcpy((void *)&f.device_config, &device_config,
+                  sizeof(device_config), true);
     flash_update_last_saved_scene(0);
     flash_update_last_mode(M_LIVE);
     flashc_memset8((void *)&f.fresh, FIRSTRUN_KEY, 1, true);
@@ -129,7 +130,8 @@ void flash_get_cal(cal_data_t *cal) {
 }
 
 void flash_update_device_config(device_config_t *device_config) {
-    flashc_memcpy((void *)&f.device_config, device_config, sizeof(device_config_t), true);
+    flashc_memcpy((void *)&f.device_config, device_config,
+                  sizeof(device_config_t), true);
 }
 
 void flash_get_device_config(device_config_t *device_config) {

--- a/module/flash.c
+++ b/module/flash.c
@@ -33,6 +33,7 @@ typedef const struct {
     tele_mode_t last_mode;
     uint8_t fresh;
     cal_data_t cal;
+    device_config_t device_config;
 } nvram_data_t;
 
 
@@ -60,6 +61,8 @@ void flash_prepare() {
 
     cal_data_t cal = { 0, 16383, 0, 16383 };
     flashc_memcpy((void *)&f.cal, &cal, sizeof(cal), true);
+    device_config_t device_config = { .flip = 0 };
+    flashc_memcpy((void *)&f.device_config, &device_config, sizeof(device_config), true);
     flash_update_last_saved_scene(0);
     flash_update_last_mode(M_LIVE);
     flashc_memset8((void *)&f.fresh, FIRSTRUN_KEY, 1, true);
@@ -123,6 +126,14 @@ void flash_update_cal(cal_data_t *cal) {
 
 void flash_get_cal(cal_data_t *cal) {
     *cal = f.cal;
+}
+
+void flash_update_device_config(device_config_t *device_config) {
+    flashc_memcpy((void *)&f.device_config, device_config, sizeof(device_config_t), true);
+}
+
+void flash_get_device_config(device_config_t *device_config) {
+    *device_config = f.device_config;
 }
 
 static void pack_grid(scene_state_t *scene) {

--- a/module/flash.h
+++ b/module/flash.h
@@ -21,5 +21,9 @@ tele_mode_t flash_last_mode(void);
 void flash_update_last_mode(tele_mode_t mode);
 void flash_update_cal(cal_data_t *);
 void flash_get_cal(cal_data_t *);
+void flash_update_cal(cal_data_t *);
+void flash_get_cal(cal_data_t *);
+void flash_update_device_config(device_config_t *);
+void flash_get_device_config(device_config_t *);
 
 #endif

--- a/module/globals.h
+++ b/module/globals.h
@@ -32,6 +32,11 @@ typedef enum {
     M_HELP
 } tele_mode_t;
 
+// device config
+typedef struct {
+    uint8_t flip;
+} device_config_t;
+
 void set_mode(tele_mode_t mode);
 void set_last_mode(void);
 void clear_delays_and_slews(scene_state_t *ss);

--- a/module/globals.h
+++ b/module/globals.h
@@ -33,9 +33,7 @@ typedef enum {
 } tele_mode_t;
 
 // device config
-typedef struct {
-    uint8_t flip;
-} device_config_t;
+typedef struct { uint8_t flip; } device_config_t;
 
 void set_mode(tele_mode_t mode);
 void set_last_mode(void);

--- a/module/main.c
+++ b/module/main.c
@@ -213,7 +213,8 @@ void cvTimer_callback(void* o) {
             a1 = aout[2].now >> 2;
             a2 = aout[1].now >> 2;
             a3 = aout[0].now >> 2;
-        } else {
+        }
+        else {
             a0 = aout[0].now >> 2;
             a1 = aout[1].now >> 2;
             a2 = aout[2].now >> 2;
@@ -848,7 +849,7 @@ void tele_metro_reset() {
 
 void tele_tr(uint8_t i, int16_t v) {
     uint32_t pin = B08 + (device_config.flip ? 3 - i : i);
-    
+
     if (v)
         gpio_set_pin_high(pin);
     else
@@ -972,7 +973,7 @@ int main(void) {
     // load device config
     flash_get_device_config(&device_config);
     update_device_config(0);
-    
+
     // load calibration data from flash
     flash_get_cal(&scene_state.cal);
     ss_update_param_scale(&scene_state);

--- a/simulator/tt.c
+++ b/simulator/tt.c
@@ -70,6 +70,8 @@ void tele_ii_tx(uint8_t addr, uint8_t *data, uint8_t l) {
 
 void tele_vars_updated() {}
 
+void device_flip() {}
+
 void tele_ii_rx(uint8_t addr, uint8_t *data, uint8_t l) {
     printf("II_rx  addr:%" PRIu8 " l:%" PRIu8, addr, l);
     printf("\n");

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -153,6 +153,7 @@
         "CV.SET"      => { MATCH_OP(E_OP_CV_SET); };
         "MUTE"        => { MATCH_OP(E_OP_MUTE); };
         "STATE"       => { MATCH_OP(E_OP_STATE); };
+        "DEVICE.FLIP" => { MATCH_OP(E_OP_DEVICE_FLIP); };
 
         # maths
         "ADD"         => { MATCH_OP(E_OP_ADD); };

--- a/src/ops/hardware.c
+++ b/src/ops/hardware.c
@@ -63,6 +63,8 @@ static void op_MUTE_set(const void *data, scene_state_t *ss, exec_state_t *es,
                         command_state_t *cs);
 static void op_STATE_get(const void *data, scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs);
+static void op_DEVICE_FLIP_get(const void *data, scene_state_t *ss, 
+                            exec_state_t *es, command_state_t *cs);
 
 
 // clang-format off
@@ -89,6 +91,7 @@ const tele_op_t op_IN_CAL_RESET  = MAKE_GET_OP (IN.CAL.RESET, op_IN_CAL_RESET_se
 const tele_op_t op_PARAM_CAL_MIN = MAKE_GET_OP (PARAM.CAL.MIN, op_PARAM_CAL_MIN_set, 0, true);
 const tele_op_t op_PARAM_CAL_MAX = MAKE_GET_OP (PARAM.CAL.MAX, op_PARAM_CAL_MAX_set, 0, true);
 const tele_op_t op_PARAM_CAL_RESET  = MAKE_GET_OP (PARAM.CAL.RESET, op_PARAM_CAL_RESET_set, 0, false);
+const tele_op_t op_DEVICE_FLIP   = MAKE_GET_OP (DEVICE.FLIP, op_DEVICE_FLIP_get, 0, false);
 // clang-format on
 
 static void op_CV_get(const void *NOTUSED(data), scene_state_t *ss,
@@ -490,4 +493,9 @@ static void op_STATE_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     }
     else
         cs_push(cs, 0);
+}
+
+static void op_DEVICE_FLIP_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
+                         exec_state_t *NOTUSED(es), command_state_t *cs) {
+    device_flip();
 }

--- a/src/ops/hardware.c
+++ b/src/ops/hardware.c
@@ -63,8 +63,8 @@ static void op_MUTE_set(const void *data, scene_state_t *ss, exec_state_t *es,
                         command_state_t *cs);
 static void op_STATE_get(const void *data, scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs);
-static void op_DEVICE_FLIP_get(const void *data, scene_state_t *ss, 
-                            exec_state_t *es, command_state_t *cs);
+static void op_DEVICE_FLIP_get(const void *data, scene_state_t *ss,
+                               exec_state_t *es, command_state_t *cs);
 
 
 // clang-format off
@@ -495,7 +495,8 @@ static void op_STATE_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
         cs_push(cs, 0);
 }
 
-static void op_DEVICE_FLIP_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                         exec_state_t *NOTUSED(es), command_state_t *cs) {
+static void op_DEVICE_FLIP_get(const void *NOTUSED(data),
+                               scene_state_t *NOTUSED(ss),
+                               exec_state_t *NOTUSED(es), command_state_t *cs) {
     device_flip();
 }

--- a/src/ops/hardware.h
+++ b/src/ops/hardware.h
@@ -26,5 +26,6 @@ extern const tele_op_t op_TR_P;
 extern const tele_op_t op_CV_SET;
 extern const tele_op_t op_MUTE;
 extern const tele_op_t op_STATE;
+extern const tele_op_t op_DEVICE_FLIP;
 
 #endif

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -72,7 +72,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     &op_PARAM_SCALE, &op_IN_CAL_MIN, &op_IN_CAL_MAX, &op_IN_CAL_RESET,
     &op_PARAM_CAL_MIN, &op_PARAM_CAL_MAX, &op_PARAM_CAL_RESET, &op_PRM, &op_TR,
     &op_TR_POL, &op_TR_TIME, &op_TR_TOG, &op_TR_PULSE, &op_TR_P, &op_CV_SET,
-    &op_MUTE, &op_STATE,
+    &op_MUTE, &op_STATE, &op_DEVICE_FLIP,
 
     // maths
     &op_ADD, &op_SUB, &op_MUL, &op_DIV, &op_MOD, &op_RAND, &op_RND, &op_RRAND,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -128,6 +128,7 @@ typedef enum {
     E_OP_CV_SET,
     E_OP_MUTE,
     E_OP_STATE,
+    E_OP_DEVICE_FLIP,
     E_OP_ADD,
     E_OP_SUB,
     E_OP_MUL,

--- a/src/teletype_io.h
+++ b/src/teletype_io.h
@@ -52,4 +52,7 @@ void tele_profile_delay(uint8_t);
 // emulate grid key press
 extern void grid_key_press(uint8_t x, uint8_t y, uint8_t z);
 
+// manage device config
+extern void device_flip(void);
+
 #endif

--- a/tests/main.c
+++ b/tests/main.c
@@ -35,6 +35,7 @@ void tele_profile_delay(uint8_t d)  {}
 bool tele_get_input_state(uint8_t n) {
     return false;
 }
+void device_flip() {}
 
 void tele_save_calibration() {}
 


### PR DESCRIPTION
#### What does this PR do?

New op - `DEVICE.FLIP`. Flips the screen/inputs/outputs, useful for mounting teletype upside down.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-ergonomics-firmware-fix/15962

#### I have,
* [x] updated CHANGELOG.md
* [x] updated the documentation
