### PR TITLE
DEL.X / DEL.R ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - **NEW**: new op: DEVICE.FLIP
 - **FIX**: [some keyboards losing keystrokes](https://github.com/monome/teletype/issues/156)
+- **NEW**: new op: DEL.X
+- **NEW**: new op: DEL.R
+- **IMP**: DELAY_SIZE incresed to 16 from 8
 
 ## v3.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@
 - **FIX**: [some keyboards losing keystrokes](https://github.com/monome/teletype/issues/156)
 - **NEW**: new op: DEL.X
 - **NEW**: new op: DEL.R
-- **IMP**: DELAY_SIZE incresed to 16 from 8
+- **IMP**: DELAY_SIZE increased to 16 from 8
 
 ## v3.0
 

--- a/docs/ops/delay.toml
+++ b/docs/ops/delay.toml
@@ -3,7 +3,7 @@ prototype = "DEL x: ..."
 short = "Delay command by `x` ms"
 description = """
 Delay the command following the colon by `x` ms by placing it into a buffer. 
-The buffer can hold up to 8 commands. If the buffer is full, additional commands
+The buffer can hold up to 16 commands. If the buffer is full, additional commands
 will be discarded.
 """
 ["DEL.CLR"]
@@ -11,4 +11,20 @@ prototype = "DEL.CLR"
 short = "Clear the delay buffer"
 description = """
 Clear the delay buffer, cancelling the pending commands.
+"""
+["DEL.X"]
+prototype = "DEL.X x y: ..."
+short = "Queue 'x' delayed commands at 'y' ms intervals"
+description = """
+Delay the command following the colon 'x' times at intervals of `y` ms by placing it into a buffer. 
+The buffer can hold up to 16 commands. If the buffer is full, additional commands
+will be discarded.
+"""
+["DEL.R"]
+prototype = "DEL.R x y: ..."
+short = "Trigger '1' command immediately, and queue 'x' minus '1' delayed commands at 'y' ms intervals"
+description = """
+Delay the command following the colon once immediately, and 'x' minus '1' times at intervals of `y` ms by placing it into a buffer. 
+The buffer can hold up to 16 commands. If the buffer is full, additional commands
+will be discarded.
 """

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -585,7 +585,8 @@
         # delay
         "PROB"        => { MATCH_MOD(E_MOD_PROB); };
         "DEL"         => { MATCH_MOD(E_MOD_DEL); };
-        "RAT"         => { MATCH_MOD(E_MOD_RAT); };
+        "XDEL"        => { MATCH_MOD(E_MOD_XDEL); };
+        "XDEL.R"      => { MATCH_MOD(E_MOD_XDEL_R); };
 
         # matrixarchate
         "MA.SELECT"   => { MATCH_OP(E_OP_MA_SELECT); };

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -585,6 +585,7 @@
         # delay
         "PROB"        => { MATCH_MOD(E_MOD_PROB); };
         "DEL"         => { MATCH_MOD(E_MOD_DEL); };
+        "RAT"         => { MATCH_MOD(E_MOD_RAT); };
 
         # matrixarchate
         "MA.SELECT"   => { MATCH_OP(E_OP_MA_SELECT); };

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -586,8 +586,8 @@
         # delay
         "PROB"        => { MATCH_MOD(E_MOD_PROB); };
         "DEL"         => { MATCH_MOD(E_MOD_DEL); };
-        "XDEL"        => { MATCH_MOD(E_MOD_XDEL); };
-        "XDEL.R"      => { MATCH_MOD(E_MOD_XDEL_R); };
+        "DEL.X"       => { MATCH_MOD(E_MOD_DEL_X); };
+        "DEL.R"       => { MATCH_MOD(E_MOD_DEL_R); };
 
         # matrixarchate
         "MA.SELECT"   => { MATCH_OP(E_OP_MA_SELECT); };

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -4,9 +4,9 @@
 #include "teletype.h"
 #include "teletype_io.h"
 
-static void delay_common_add(scene_state_t *ss, exec_state_t *es, 
-                        int16_t i, int16_t delay_time,
-                        const tele_command_t *post_command);
+static void delay_common_add(scene_state_t *ss, exec_state_t *es, int16_t i,
+                             int16_t delay_time,
+                             const tele_command_t *post_command);
 
 static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs,
@@ -16,28 +16,30 @@ static void op_DEL_CLR_get(const void *data, scene_state_t *ss,
                            exec_state_t *es, command_state_t *cs);
 
 static void mod_DEL_X_func(scene_state_t *ss, exec_state_t *es,
-                         command_state_t *cs,
-                         const tele_command_t *post_command);
+                           command_state_t *cs,
+                           const tele_command_t *post_command);
 
 static void mod_DEL_R_func(scene_state_t *ss, exec_state_t *es,
-                         command_state_t *cs,
-                         const tele_command_t *post_command);
+                           command_state_t *cs,
+                           const tele_command_t *post_command);
 
 const tele_mod_t mod_DEL = MAKE_MOD(DEL, mod_DEL_func, 1);
 const tele_op_t op_DEL_CLR = MAKE_GET_OP(DEL.CLR, op_DEL_CLR_get, 0, false);
 const tele_mod_t mod_DEL_X = MAKE_MOD(DEL.X, mod_DEL_X_func, 2);
 const tele_mod_t mod_DEL_R = MAKE_MOD(DEL.R, mod_DEL_R_func, 2);
 
-//common code to queue a delay shared between all delay ops
-//NOTE it is the responsibility of the callee to call tele_has_delays
-static void delay_common_add(scene_state_t *ss, exec_state_t *es, 
-                        int16_t i, int16_t delay_time,
-                        const tele_command_t *post_command) {
+// common code to queue a delay shared between all delay ops
+// NOTE it is the responsibility of the callee to call tele_has_delays
+static void delay_common_add(scene_state_t *ss, exec_state_t *es, int16_t i,
+                             int16_t delay_time,
+                             const tele_command_t *post_command) {
+    if (i < DELAY_SIZE) {
         ss->delay.count++;
         ss->delay.time[i] = delay_time;
         ss->delay.origin_script[i] = es_variables(es)->script_number;
         ss->delay.origin_i[i] = es_variables(es)->i;
         copy_command(&ss->delay.commands[i], post_command);
+    }
 }
 
 static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
@@ -64,65 +66,65 @@ static void op_DEL_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
     clear_delays(ss);
 }
 
-static void mod_DEL_X_func(scene_state_t *ss, exec_state_t *es, 
-				command_state_t *cs,
-				const tele_command_t *post_command) {
+static void mod_DEL_X_func(scene_state_t *ss, exec_state_t *es,
+                           command_state_t *cs,
+                           const tele_command_t *post_command) {
     int16_t i = 0;
     int16_t num_delays = cs_pop(cs);
     int16_t delay_time = cs_pop(cs);
     int16_t delay_time_next;
 
-    if (delay_time < 1) delay_time = 1; //minimum delay time = 1ms
+    if (delay_time < 1) delay_time = 1;  // minimum delay time = 1ms
 
-    delay_time_next = delay_time; //set first delay time to delay time
+    delay_time_next = delay_time;  // set first delay time to delay time
 
     // 0 is the magic number for an empty slot.
     // Be careful not to set delay.time[i] to 0 before calling this function.
     while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
 
     while (i < DELAY_SIZE && num_delays > 0) {
-        //queue the delay
-        delay_common_add(ss, es, i, delay_time_next, post_command); 
+        // queue the delay
+        delay_common_add(ss, es, i, delay_time_next, post_command);
 
-        //increment delay time for next delay
-        //normalise incremented value to stop negative wrap from increment
+        // increment delay time for next delay
+        // normalise incremented value to stop negative wrap from increment
         delay_time_next += delay_time;
-        delay_time_next = normalise_value(1, 32767, 1, delay_time_next); 
+        delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
 
-        num_delays--; 
-	    i++;
+        num_delays--;
+        i++;
     }
 
     tele_has_delays(ss->delay.count > 0);
 }
 
-static void mod_DEL_R_func(scene_state_t *ss, exec_state_t *es, 
-				command_state_t *cs,
-				const tele_command_t *post_command) {
+static void mod_DEL_R_func(scene_state_t *ss, exec_state_t *es,
+                           command_state_t *cs,
+                           const tele_command_t *post_command) {
     int16_t i = 0;
-    int16_t num_delays = cs_pop(cs); //number of chained delays
-    int16_t delay_time = cs_pop(cs); //delay time
-    int16_t delay_time_next; //incremented delay time 
+    int16_t num_delays = cs_pop(cs);  // number of chained delays
+    int16_t delay_time = cs_pop(cs);  // delay time
+    int16_t delay_time_next;          // incremented delay time
 
-    if (delay_time < 1) delay_time = 1; //minimum delay time = 1ms
+    if (delay_time < 1) delay_time = 1;  // minimum delay time = 1ms
 
-    delay_time_next = 1; //set first delay time to 1ms to trigger immediately 
+    delay_time_next = 1;  // set first delay time to 1ms to trigger immediately
 
     // 0 is the magic number for an empty slot.
     // Be careful not to set delay.time[i] to 0 before calling this function.
     while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
 
     while (i < DELAY_SIZE && num_delays > 0) {
-        //queue the delay
-        delay_common_add(ss, es, i, delay_time_next, post_command); 
+        // queue the delay
+        delay_common_add(ss, es, i, delay_time_next, post_command);
 
-        //increment delay time for next delay
-        //normalise incremented value to stop negative wrap from increment
+        // increment delay time for next delay
+        // normalise incremented value to stop negative wrap from increment
         delay_time_next += delay_time;
-        delay_time_next = normalise_value(1, 32767, 1, delay_time_next); 
+        delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
 
-	    num_delays--;
-	    i++;
+        num_delays--;
+        i++;
     }
 
     tele_has_delays(ss->delay.count > 0);

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -11,9 +11,13 @@ static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
 static void op_DEL_CLR_get(const void *data, scene_state_t *ss,
                            exec_state_t *es, command_state_t *cs);
 
+static void mod_RAT_func(scene_state_t *ss, exec_state_t *es,
+                         command_state_t *cs,
+                         const tele_command_t *post_command);
 
 const tele_mod_t mod_DEL = MAKE_MOD(DEL, mod_DEL_func, 1);
 const tele_op_t op_DEL_CLR = MAKE_GET_OP(DEL.CLR, op_DEL_CLR_get, 0, false);
+const tele_mod_t mod_RAT = MAKE_MOD(RAT, mod_RAT_func, 2);
 
 static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs,
@@ -41,4 +45,34 @@ static void op_DEL_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
                            exec_state_t *NOTUSED(es),
                            command_state_t *NOTUSED(cs)) {
     clear_delays(ss);
+}
+
+static void mod_RAT_func(scene_state_t *ss, exec_state_t *es, 
+				command_state_t *cs,
+				const tele_command_t *post_command) {
+    int16_t i = 0;
+    int16_t a = cs_pop(cs); //delay time
+    int16_t b = cs_pop(cs); //number of chained delays
+    int16_t c; //incremented delay time 
+
+    if (a < 1) a = 1;
+    c = a;
+
+    // 0 is the magic number for an empty slot.
+    // Be careful not to set delay.time[i] to 0 before calling this function.
+    while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
+
+    while (i < DELAY_SIZE && b > 0) {
+        ss->delay.count++;
+        ss->delay.time[i] = c;
+        ss->delay.origin_script[i] = es_variables(es)->script_number;
+        ss->delay.origin_i[i] = es_variables(es)->i;
+        copy_command(&ss->delay.commands[i], post_command);
+	
+	    c += a; //increment delay time for next chained delay
+	    b--; //decrement delay chain count
+	    i++;
+    }
+
+    tele_has_delays(ss->delay.count > 0);
 }

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -4,7 +4,7 @@
 #include "teletype.h"
 #include "teletype_io.h"
 
-static void delay_common_add(scene_state_t *ss, exec_state_t *es, int16_t i,
+static bool delay_common_add(scene_state_t *ss, exec_state_t *es,
                              int16_t delay_time,
                              const tele_command_t *post_command);
 
@@ -30,34 +30,37 @@ const tele_mod_t mod_DEL_R = MAKE_MOD(DEL.R, mod_DEL_R_func, 2);
 
 // common code to queue a delay shared between all delay ops
 // NOTE it is the responsibility of the callee to call tele_has_delays
-static void delay_common_add(scene_state_t *ss, exec_state_t *es, int16_t i,
+static bool delay_common_add(scene_state_t *ss, exec_state_t *es,
                              int16_t delay_time,
                              const tele_command_t *post_command) {
+    int16_t i = 0;
+
+    // 0 is the magic number for an empty slot.
+    // Be careful not to set delay.time[i] to 0 before calling this function.
+    while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
+
+    if (delay_time < 1) delay_time = 1;
+
     if (i < DELAY_SIZE) {
         ss->delay.count++;
         ss->delay.time[i] = delay_time;
         ss->delay.origin_script[i] = es_variables(es)->script_number;
         ss->delay.origin_i[i] = es_variables(es)->i;
         copy_command(&ss->delay.commands[i], post_command);
+
+        return true;
     }
+
+    return false;
 }
 
 static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs,
                          const tele_command_t *post_command) {
-    int16_t i = 0;
     int16_t delay_time = cs_pop(cs);
 
-    if (delay_time < 1) delay_time = 1;
-
-    // 0 is the magic number for an empty slot.
-    // Be careful not to set delay.time[i] to 0 before calling this function.
-    while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
-
-    if (i < DELAY_SIZE) {
-        delay_common_add(ss, es, i, delay_time, post_command);
-        tele_has_delays(ss->delay.count > 0);
-    }
+    delay_common_add(ss, es, delay_time, post_command);
+    tele_has_delays(ss->delay.count > 0);
 }
 
 static void op_DEL_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
@@ -69,30 +72,23 @@ static void op_DEL_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
 static void mod_DEL_X_func(scene_state_t *ss, exec_state_t *es,
                            command_state_t *cs,
                            const tele_command_t *post_command) {
-    int16_t i = 0;
     int16_t num_delays = cs_pop(cs);
     int16_t delay_time = cs_pop(cs);
     int16_t delay_time_next;
 
-    if (delay_time < 1) delay_time = 1;  // minimum delay time = 1ms
+    if (delay_time < 1) delay_time = 1;
 
-    delay_time_next = delay_time;  // set first delay time to delay time
+    // set first delay time to delay time
+    delay_time_next = delay_time;  
 
-    // 0 is the magic number for an empty slot.
-    // Be careful not to set delay.time[i] to 0 before calling this function.
-    while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
-
-    while (i < DELAY_SIZE && num_delays > 0) {
-        // queue the delay
-        delay_common_add(ss, es, i, delay_time_next, post_command);
-
+    while ( num_delays > 0 && delay_common_add(ss, es, delay_time_next, post_command) ) 
+    {
         // increment delay time for next delay
         // normalise incremented value to stop negative wrap from increment
         delay_time_next += delay_time;
         delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
 
         num_delays--;
-        i++;
     }
 
     tele_has_delays(ss->delay.count > 0);
@@ -101,30 +97,23 @@ static void mod_DEL_X_func(scene_state_t *ss, exec_state_t *es,
 static void mod_DEL_R_func(scene_state_t *ss, exec_state_t *es,
                            command_state_t *cs,
                            const tele_command_t *post_command) {
-    int16_t i = 0;
-    int16_t num_delays = cs_pop(cs);  // number of chained delays
-    int16_t delay_time = cs_pop(cs);  // delay time
-    int16_t delay_time_next;          // incremented delay time
+    int16_t num_delays = cs_pop(cs);
+    int16_t delay_time = cs_pop(cs);
+    int16_t delay_time_next;
 
-    if (delay_time < 1) delay_time = 1;  // minimum delay time = 1ms
+    if (delay_time < 1) delay_time = 1;
 
-    delay_time_next = 1;  // set first delay time to 1ms to trigger immediately
+    // set first delay time to 1ms to trigger immediately
+    delay_time_next = 1;  
 
-    // 0 is the magic number for an empty slot.
-    // Be careful not to set delay.time[i] to 0 before calling this function.
-    while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
-
-    while (i < DELAY_SIZE && num_delays > 0) {
-        // queue the delay
-        delay_common_add(ss, es, i, delay_time_next, post_command);
-
+    while ( num_delays > 0 && delay_common_add(ss, es, delay_time_next, post_command) )
+    {
         // increment delay time for next delay
         // normalise incremented value to stop negative wrap from increment
         delay_time_next += delay_time;
         delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
 
         num_delays--;
-        i++;
     }
 
     tele_has_delays(ss->delay.count > 0);

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -4,6 +4,10 @@
 #include "teletype.h"
 #include "teletype_io.h"
 
+static void add_delay_helper(scene_state_t *ss, exec_state_t *es, 
+                        int i, int delay_time,
+                        const tele_command_t *post_command);
+
 static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs,
                          const tele_command_t *post_command);
@@ -11,13 +15,28 @@ static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
 static void op_DEL_CLR_get(const void *data, scene_state_t *ss,
                            exec_state_t *es, command_state_t *cs);
 
-static void mod_RAT_func(scene_state_t *ss, exec_state_t *es,
+static void mod_XDEL_func(scene_state_t *ss, exec_state_t *es,
+                         command_state_t *cs,
+                         const tele_command_t *post_command);
+
+static void mod_XDEL_R_func(scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs,
                          const tele_command_t *post_command);
 
 const tele_mod_t mod_DEL = MAKE_MOD(DEL, mod_DEL_func, 1);
 const tele_op_t op_DEL_CLR = MAKE_GET_OP(DEL.CLR, op_DEL_CLR_get, 0, false);
-const tele_mod_t mod_RAT = MAKE_MOD(RAT, mod_RAT_func, 2);
+const tele_mod_t mod_XDEL = MAKE_MOD(XDEL, mod_XDEL_func, 2);
+const tele_mod_t mod_XDEL_R = MAKE_MOD(XDEL.R, mod_XDEL_R_func, 2);
+
+static void add_delay_helper(scene_state_t *ss, exec_state_t *es, 
+                        int i, int delay_time,
+                        const tele_command_t *post_command) {
+        ss->delay.count++;
+        ss->delay.time[i] = delay_time;
+        ss->delay.origin_script[i] = es_variables(es)->script_number;
+        ss->delay.origin_i[i] = es_variables(es)->i;
+        copy_command(&ss->delay.commands[i], post_command);
+}
 
 static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs,
@@ -37,6 +56,7 @@ static void mod_DEL_func(scene_state_t *ss, exec_state_t *es,
         ss->delay.origin_script[i] = es_variables(es)->script_number;
         ss->delay.origin_i[i] = es_variables(es)->i;
         copy_command(&ss->delay.commands[i], post_command);
+        add_delay_helper(ss, es, i, a, post_command);
         tele_has_delays(ss->delay.count > 0);
     }
 }
@@ -47,30 +67,66 @@ static void op_DEL_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
     clear_delays(ss);
 }
 
-static void mod_RAT_func(scene_state_t *ss, exec_state_t *es, 
+static void mod_XDEL_func(scene_state_t *ss, exec_state_t *es, 
 				command_state_t *cs,
 				const tele_command_t *post_command) {
     int16_t i = 0;
-    int16_t a = cs_pop(cs); //delay time
-    int16_t b = cs_pop(cs); //number of chained delays
+    int16_t a = cs_pop(cs); //number of chained delays
+    int16_t b = cs_pop(cs); //delay time
     int16_t c; //incremented delay time 
 
-    if (a < 1) a = 1;
-    c = a;
+    if (b < 1) b = 1; //minimum delay time = 1ms
+
+    c = b; //set first delay time to delay time
 
     // 0 is the magic number for an empty slot.
     // Be careful not to set delay.time[i] to 0 before calling this function.
     while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
 
-    while (i < DELAY_SIZE && b > 0) {
+    while (i < DELAY_SIZE && a > 0) {
+        /*
         ss->delay.count++;
         ss->delay.time[i] = c;
         ss->delay.origin_script[i] = es_variables(es)->script_number;
         ss->delay.origin_i[i] = es_variables(es)->i;
         copy_command(&ss->delay.commands[i], post_command);
-	
-	    c += a; //increment delay time for next chained delay
-	    b--; //decrement delay chain count
+	    */
+        add_delay_helper(ss, es, i, c, post_command); 
+	    c += b; //increment delay time for next delay
+	    a--; //decrement delay chain count
+	    i++;
+    }
+
+    tele_has_delays(ss->delay.count > 0);
+}
+
+static void mod_XDEL_R_func(scene_state_t *ss, exec_state_t *es, 
+				command_state_t *cs,
+				const tele_command_t *post_command) {
+    int16_t i = 0;
+    int16_t a = cs_pop(cs); //number of chained delays
+    int16_t b = cs_pop(cs); //delay time
+    int16_t c; //incremented delay time 
+
+    if (b < 1) b = 1; //minimum delay time = 1ms
+
+    c = 1; //set first delay time to 1ms to trigger immediately 
+
+    // 0 is the magic number for an empty slot.
+    // Be careful not to set delay.time[i] to 0 before calling this function.
+    while (ss->delay.time[i] != 0 && i != DELAY_SIZE) i++;
+
+    while (i < DELAY_SIZE && a > 0) {
+        /*
+        ss->delay.count++;
+        ss->delay.time[i] = c;
+        ss->delay.origin_script[i] = es_variables(es)->script_number;
+        ss->delay.origin_i[i] = es_variables(es)->i;
+        copy_command(&ss->delay.commands[i], post_command);
+	    */
+        add_delay_helper(ss, es, i, c, post_command); 
+	    c += b; //increment delay time for next delay
+	    a--; //decrement delay chain count
 	    i++;
     }
 

--- a/src/ops/delay.h
+++ b/src/ops/delay.h
@@ -5,5 +5,6 @@
 
 extern const tele_mod_t mod_DEL;
 extern const tele_op_t op_DEL_CLR;
+extern const tele_mod_t mod_RAT;
 
 #endif

--- a/src/ops/delay.h
+++ b/src/ops/delay.h
@@ -5,6 +5,7 @@
 
 extern const tele_mod_t mod_DEL;
 extern const tele_op_t op_DEL_CLR;
-extern const tele_mod_t mod_RAT;
+extern const tele_mod_t mod_XDEL;
+extern const tele_mod_t mod_XDEL_R;
 
 #endif

--- a/src/ops/delay.h
+++ b/src/ops/delay.h
@@ -5,7 +5,7 @@
 
 extern const tele_mod_t mod_DEL;
 extern const tele_op_t op_DEL_CLR;
-extern const tele_mod_t mod_XDEL;
-extern const tele_mod_t mod_XDEL_R;
+extern const tele_mod_t mod_DEL_X;
+extern const tele_mod_t mod_DEL_R;
 
 #endif

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -212,7 +212,7 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     &mod_OTHER, &mod_PROB,
 
     // delay
-    &mod_DEL, &mod_RAT,
+    &mod_DEL, &mod_XDEL, &mod_XDEL_R,
 
     // stack
     &mod_S

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -212,7 +212,7 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     &mod_OTHER, &mod_PROB,
 
     // delay
-    &mod_DEL, &mod_RAT
+    &mod_DEL, &mod_RAT,
 
     // stack
     &mod_S

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -212,7 +212,7 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     &mod_OTHER, &mod_PROB,
 
     // delay
-    &mod_DEL, &mod_XDEL, &mod_XDEL_R,
+    &mod_DEL, &mod_DEL_X, &mod_DEL_R,
 
     // stack
     &mod_S

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -212,7 +212,7 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     &mod_OTHER, &mod_PROB,
 
     // delay
-    &mod_DEL,
+    &mod_DEL, &mod_RAT
 
     // stack
     &mod_S

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -526,8 +526,8 @@ typedef enum {
     E_MOD_OTHER,
     E_MOD_PROB,
     E_MOD_DEL,
-    E_MOD_XDEL,
-    E_MOD_XDEL_R,
+    E_MOD_DEL_X,
+    E_MOD_DEL_R,
     E_MOD_S,
     E_MOD__LENGTH,
 } tele_mod_idx_t;

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -525,6 +525,7 @@ typedef enum {
     E_MOD_OTHER,
     E_MOD_PROB,
     E_MOD_DEL,
+    E_MOD_RAT,
     E_MOD_S,
     E_MOD__LENGTH,
 } tele_mod_idx_t;

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -525,7 +525,8 @@ typedef enum {
     E_MOD_OTHER,
     E_MOD_PROB,
     E_MOD_DEL,
-    E_MOD_RAT,
+    E_MOD_XDEL,
+    E_MOD_XDEL_R,
     E_MOD_S,
     E_MOD__LENGTH,
 } tele_mod_idx_t;

--- a/src/state.h
+++ b/src/state.h
@@ -16,7 +16,7 @@
 #define Q_LENGTH 64
 #define TR_COUNT 4
 #define TRIGGER_INPUTS 8
-#define DELAY_SIZE 8
+#define DELAY_SIZE 16
 #define STACK_OP_SIZE 16
 #define PATTERN_COUNT 4
 #define PATTERN_LENGTH 64


### PR DESCRIPTION
#### What does this PR do?
added ```DEL.X``` and ```DEL.R``` ops allowing for chained(multiple) delays at spaced intervals.  added common delay add function for all delay ops to save code space.  additionally increased the maximum number of delays from 8 to 16.

#### Provide links to any related discussion on [lines](https://llllllll.co/).
https://llllllll.co/t/teletype-3-feature-requests-and-discussion/16219/27?u=alphacactus

#### How should this be manually tested?
tested both old and new delay ops with variable delay times and number of delays.  tested edge cases such as calling ```DEL.X``` for zero delays, delay times of zero, and negative delay times.  

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated CHANGELOG.md
* [x] updated the documentation
