### PR TITLE
Switch to using `git-clang-format` for `make format`

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,4 +32,7 @@ teletype.zip: clean-zip
 		docs/cheatsheet/cheatsheet.pdf
 
 format:
+	git-clang-format -f --style=file
+
+format-all:
 	find . -type f -name "*.c" -o -name "*.h" | xargs clang-format -style=file -i

--- a/README.md
+++ b/README.md
@@ -63,7 +63,9 @@ There is a test that checks to see if the above have all been entered correctly.
 
 ## Code Formatting
 
-To format the code using `clang-format`, run `make format` in the project's root directory. This *shouldn't* format any code in the `libavr32` submodule.
+To format the code using `clang-format`, run `make format` in the project's root directory. This will _only_ format code that has not been commited, it will format _both_ staged and unstaged code.
+
+To format all the code in this repo, run `make format-all`.
 
 [libavr32]: https://github.com/monome/libavr32
 [ragel]: http://www.colm.net/open-source/ragel/


### PR DESCRIPTION
#### What does this PR do?

This PR updates the `make format` target use `git-clang-format`, which has been set to format _only_ staged and unstaged changes, instead of formatting all the code in the repo.

This should avoid issues like in #164 where new users end up formatting lots of old code, and also stop the `blame` view getting messed up. However it does mean that `make format` needs to be run each commit (which it should be anyway).

There is a `make format-all` command that has the old behaviour, I expect we'll need to run this occasional to pick up any missing changes.

I'm not 100% certain this is better than how we do it currently, but I think it is. Thoughts?

#### How should this be manually tested?

Run `make format` and `make format-all`

#### I have,
* [ ] updated CHANGELOG.md
* [x] updated the documentation
