### PR TITLE
fixes for flash initialization

### DIFF
--- a/module/flash.h
+++ b/module/flash.h
@@ -9,6 +9,7 @@
 
 #define SCENE_SLOTS 32
 
+u8 is_flash_fresh(void);
 void flash_prepare(void);
 void flash_read(uint8_t preset_no, scene_state_t *scene,
                 char (*text)[SCENE_TEXT_LINES][SCENE_TEXT_CHARS]);


### PR DESCRIPTION
#### What does this PR do?

further fixes for flash initialization:
- added a screen with a warning
- previous change would always init with blank scenes
- added a safeguard for preset_no

#### I have,
* [ ] updated `CHANGELOG.md`
* [ ] updated the documentation
* [ ] run `make format` on each commit
