### PR TITLE
bugfix: git sha1 script requires bash

### DIFF
--- a/module/Makefile
+++ b/module/Makefile
@@ -60,6 +60,8 @@
 # \asf_license_stop
 #
 
+SHELL=bash
+
 # Makefile.avr32.in defines an unused variable build, which is used in the clean
 # target, it's probably there to list other build targets
 build += ../src/scanner.c ../src/match_token.c ../module/gitversion.c
@@ -79,4 +81,4 @@ include $(MAKEFILE_PATH)
 
 # Add the git commit id to a file for use when printing out the version
 ../module/gitversion.c: ../.git/HEAD ../.git/index
-	echo "const char *git_version = \"$(shell cut -d '-' -f 1 <<< $(shell git describe --tags | cut -c 2-)) $(shell git describe --always --dirty | tr '[a-z]' '[A-Z]')\";" > $@
+	echo "const char *git_version = \"$(shell cut -d '-' -f 1 <<< $(shell git describe --tags | cut -c 2-)) $(shell git describe --always --dirty --exclude '*' | tr '[a-z]' '[A-Z]')\";" > $@


### PR DESCRIPTION
#### What does this PR do?

Without specifying a shell, make will use `/bin/sh`, which on some environments (Ubuntu, and therefore [this](https://hub.docker.com/r/dewb/monome-build/) Dockerfile) is not `bash`. This causes redirection to fail in the bit that generates the git sha1 to embed in the firmware. Also `git describe --always --dirty` was winding up with two different version numbers in the string displayed on Teletype, like `3.0.0 v2.2.0-alpha.7-244` as well as the wrong tag for some reason, this change adds `--exclude '*'` to omit tags in this part so you just get a version + sha like `3.0.0 0F3DAA7-DIRTY`.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

This was causing some confusion because the version number was coming out weird from my builds: [1](https://llllllll.co/t/teletype-3-feature-requests-and-discussion/16219/348), [2](https://llllllll.co/t/teletype-3-0/11232/421)

#### How should this be manually tested?

Build ye Firm-Ware, flafhe ye Module.

#### I have,
* [x] updated `CHANGELOG.md` (N/A)
* [x] updated the documentation (N/A)
* [x] run `make format` on each commit (N/A)
