### PR TITLE
fix $.POL change that broke inputs w/ DEVICE.FLIP

### DIFF
--- a/module/main.c
+++ b/module/main.c
@@ -461,7 +461,7 @@ void handler_MscConnect(int32_t data) {
 void handler_Trigger(int32_t data) {
     u8 input = device_config.flip ? 7 - data : data;
     if (!ss_get_mute(&scene_state, input)) {
-        bool tr_state = gpio_get_pin_value(A00 + input);
+        bool tr_state = gpio_get_pin_value(A00 + data);
         if (tr_state) {
             if (scene_state.variables.script_pol[input] & 1) {
                 run_script(&scene_state, input);


### PR DESCRIPTION
#### What does this PR do?

Fixes #181 - changes for `$.POL` broke input processing when `DEVICE.FLIP`ped

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-3-feature-requests-and-discussion/16219/364

#### How should this be manually tested?

`DEVICE.FLIP` and check each trigger input.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

https://github.com/monome/teletype/issues/181

#### I have,
* [ ] updated `CHANGELOG.md` - wasn't sure if this should be marked a *FIX* as this is a pretty major breakage but `DEVICE.FLIP` was introduced in 3.1.0
* [x] updated the documentation (N/A)
* [x] run `make format` on each commit
