### PR TITLE
bugfix: manually trigger cvTimer on cv change

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.1.x
+
+- **FIX**: improve DAC latency when using `CV` ops
+
 ## v3.1.0
 
 - **NEW**: new op: DEVICE.FLIP

--- a/module/main.c
+++ b/module/main.c
@@ -894,7 +894,7 @@ void tele_cv(uint8_t i, int16_t v, uint8_t s) {
 
     aout[i].a = aout[i].now << 16;
 
-    timer_manual(&adcTimer);
+    timer_manual(&cvTimer);
 }
 
 void tele_cv_slew(uint8_t i, int16_t v) {


### PR DESCRIPTION
#### What does this PR do?

Changes what appears to be a typo manually triggering `adcTimer` instead of `cvTimer` in `tele_cv`, which was causing DACs not to update until the CV timer expires when using `CV` ops.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-timing-issues-cv-edition/24193/9?u=csboling

#### How should this be manually tested?

Report from testing with an oscilloscope on [Lines](https://llllllll.co/t/teletype-timing-issues-cv-edition/24193/14): "CV state changes have c. 200us of latency + c. 500us of jitter after this update" (down from as much as 6ms)

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md` 
* [x] updated the documentation - N/A
* [x] run `make format` on each commit - N/A
