### PR TITLE
Call init or metro with SCRIPT op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,9 @@
 
 - **FIX**: improve DAC latency when using `CV` ops
 
+## v3.1.x
+- **NEW**: call metro / init with `SCRIPT 9` / `SCRIPT 10`
+
 ## v3.1.0
 
 - **NEW**: new op: DEVICE.FLIP

--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -160,9 +160,9 @@ short = "potentially execute command with probability `x` (0-100)"
 prototype = "SCRIPT"
 prototype_set = "SCRIPT x"
 aliases = ["$"]
-short = "get current script number, or execute script `x` (1-8), recursion allowed"
+short = "get current script number, or execute script `x` (1-10), recursion allowed"
 description = """
-Execute script `x` (1-8), recursion allowed.
+Execute script `x` (1-10, 9 = metro, 10 = init), recursion allowed.
 
 There is a limit of 8 for the maximum number of nested calls to `SCRIPT` to stop infinite loops from locking up the Teletype.
 """

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -242,7 +242,7 @@ static void op_SCRIPT_get(const void *NOTUSED(data), scene_state_t *ss,
 static void op_SCRIPT_set(const void *NOTUSED(data), scene_state_t *ss,
                           exec_state_t *es, command_state_t *cs) {
     uint16_t a = cs_pop(cs) - 1;
-    if (a > TT_SCRIPT_8 || a < TT_SCRIPT_1) return;
+    if (a > INIT_SCRIPT || a < TT_SCRIPT_1) return;
 
     es_push(es);
     // an overflow causes all future SCRIPT calls to fail


### PR DESCRIPTION
#### What does this PR do?

Tweaks the range check in the `SCRIPT` op so you can use `SCRIPT 9` or `SCRIPT 10` to call metro or init, respectively. This is consistent with the numbering used by the function keys and the grid ops and can be useful for programmatically re-initializing a scene, humanizing a clock, etc.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-workflow-basics-and-questions/12392/766

#### How should this be manually tested?

Place triggers in metro and init scripts, call them manually with `SCRIPT 9` and `SCRIPT 10` from live mode.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] run `make format` on each commit
