### PR TITLE
`KR.DUR` getter op for kria duration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@
 - **NEW**: new ops: `LROT` (alias `<<<`), `RROT` (alias `>>>`)
 - **NEW**: `LSH` and `RSH` shift the opposite direction when passed a negative shift amount
 - **NEW**: new op: `SGN` (sign of argument)
+- **NEW**: new kria remote op: `KR.DUR`
 
 ## v3.1.0
 

--- a/docs/ops/ansible.toml
+++ b/docs/ops/ansible.toml
@@ -145,6 +145,11 @@ description = """
 Get or change the step direction. Numbered from 0.
 """
 
+["KR.DUR"]
+prototype = "KR.DUR x "
+short = "get the current duration value for channel `x`"
+
+
 ["ME.PRE"]
 prototype = "ME.PRE"
 prototype_set = "ME.PRE x"

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -650,7 +650,7 @@ const char* help11[HELP11_LENGTH] = { "11/13 TELEX OUTPUT",
                                       "TO.CV.RESET X",
                                       "    RESET CV CALIB" };
 
-#define HELP12_LENGTH 138
+#define HELP12_LENGTH 140
 const char* help12[HELP12_LENGTH] = { "12/13 ANSIBLE",
                                       " ",
                                       "ANS.G.LED X Y",
@@ -712,6 +712,8 @@ const char* help12[HELP12_LENGTH] = { "12/13 ANSIBLE",
                                       "    GET/SET CUED PATTERN X",
                                       "KR.DIR / KR.DIR X",
                                       "    GET/SET STEP DIRECTION X",
+                                      "KR.DUR X",
+                                      "    GET CHANNEL X DURATION",
                                       "KR.PG / KR.PG X",
                                       "    GET/SET ACTIVE PAGE",
                                       "ME.PRE / ME.PRE X",

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -327,6 +327,7 @@
         "KR.PG"       => { MATCH_OP(E_OP_KR_PG); };
         "KR.CUE"      => { MATCH_OP(E_OP_KR_CUE); };
         "KR.DIR"      => { MATCH_OP(E_OP_KR_DIR); };
+        "KR.DUR"      => { MATCH_OP(E_OP_KR_DUR); };
         "ME.PRE"      => { MATCH_OP(E_OP_ME_PRE); };
         "ME.RES"      => { MATCH_OP(E_OP_ME_RES); };
         "ME.STOP"     => { MATCH_OP(E_OP_ME_STOP); };

--- a/src/ops/ansible.c
+++ b/src/ops/ansible.c
@@ -74,6 +74,8 @@ static void op_KR_DIR_get(const void *data, scene_state_t *ss, exec_state_t *es,
                           command_state_t *cs);
 static void op_KR_DIR_set(const void *data, scene_state_t *ss, exec_state_t *es,
                           command_state_t *cs);
+static void op_KR_DUR_get(const void *data, scene_state_t *ss, exec_state_t *es,
+                          command_state_t *cs);
 static void op_ME_PRE_get(const void *data, scene_state_t *ss, exec_state_t *es,
                           command_state_t *cs);
 static void op_ME_PRE_set(const void *data, scene_state_t *ss, exec_state_t *es,
@@ -184,7 +186,8 @@ const tele_op_t op_KR_TMUTE    = MAKE_GET_OP    (KR.TMUTE   , op_KR_TMUTE_get   
 const tele_op_t op_KR_CLK      = MAKE_GET_OP    (KR.CLK     , op_KR_CLK_get                           , 1, false);
 const tele_op_t op_KR_PG       = MAKE_GET_SET_OP(KR.PG      , op_KR_PG_get       , op_KR_PG_set       , 0, true);
 const tele_op_t op_KR_CUE      = MAKE_GET_SET_OP(KR.CUE     , op_KR_CUE_get      , op_KR_CUE_set      , 0, true);
-const tele_op_t op_KR_DIR      = MAKE_GET_SET_OP(KR.DIR      , op_KR_DIR_get     , op_KR_DIR_set      , 1, true);
+const tele_op_t op_KR_DIR      = MAKE_GET_SET_OP(KR.DIR     , op_KR_DIR_get     , op_KR_DIR_set       , 1, true);
+const tele_op_t op_KR_DUR      = MAKE_GET_OP    (KR.DUR     , op_KR_DUR_get                           , 1, true);
 
 const tele_op_t op_ME_PRE      = MAKE_GET_SET_OP(ME.PRE     , op_ME_PRE_get      , op_ME_PRE_set      , 0, true);
 const tele_op_t op_ME_RES      = MAKE_GET_OP    (ME.RES     , op_ME_RES_get                           , 1, false);
@@ -606,6 +609,20 @@ static void op_KR_DIR_set(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     uint8_t d[] = { II_KR_DIR, n, x };
     tele_ii_tx(II_KR_ADDR, d, 3);
 }
+
+static void op_KR_DUR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
+                          exec_state_t *NOTUSED(es), command_state_t *cs) {
+    int16_t a = cs_pop(cs);
+    a--;
+    uint8_t d[] = { II_KR_DURATION | II_GET, a & 0x3 };
+    uint8_t addr = II_KR_ADDR;
+    tele_ii_tx(addr, d, 2);
+    d[0] = 0;
+    d[1] = 0;
+    tele_ii_rx(addr, d, 2);
+    cs_push(cs, (d[0] << 8) + d[1]);
+}
+
 
 static void op_ME_PRE_set(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
                           exec_state_t *NOTUSED(es), command_state_t *cs) {

--- a/src/ops/ansible.h
+++ b/src/ops/ansible.h
@@ -25,6 +25,7 @@ extern const tele_op_t op_KR_CLK;
 extern const tele_op_t op_KR_PG;
 extern const tele_op_t op_KR_CUE;
 extern const tele_op_t op_KR_DIR;
+extern const tele_op_t op_KR_DUR;
 
 extern const tele_op_t op_ME_PRE;
 extern const tele_op_t op_ME_RES;

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -125,7 +125,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     &op_ANS_APP,
     &op_KR_PRE, &op_KR_PAT, &op_KR_SCALE, &op_KR_PERIOD, &op_KR_POS,
     &op_KR_L_ST, &op_KR_L_LEN, &op_KR_RES, &op_KR_CV, &op_KR_MUTE, &op_KR_TMUTE,
-    &op_KR_CLK, &op_KR_PG, &op_KR_CUE, &op_KR_DIR,
+    &op_KR_CLK, &op_KR_PG, &op_KR_CUE, &op_KR_DIR, &op_KR_DUR,
     &op_ME_PRE, &op_ME_RES, &op_ME_STOP, &op_ME_SCALE,
     &op_ME_PERIOD, &op_ME_CV, &op_LV_PRE, &op_LV_RES, &op_LV_POS, &op_LV_L_ST,
     &op_LV_L_LEN, &op_LV_L_DIR, &op_LV_CV, &op_CY_PRE, &op_CY_RES, &op_CY_POS,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -284,6 +284,7 @@ typedef enum {
     E_OP_KR_PG,
     E_OP_KR_CUE,
     E_OP_KR_DIR,
+    E_OP_KR_DUR,
     E_OP_ME_PRE,
     E_OP_ME_RES,
     E_OP_ME_STOP,


### PR DESCRIPTION
#### What does this PR do?
Adds a teletype op `KR.DUR` for reading the trigger pulse duration from Kria. See https://github.com/monome/ansible/pull/74

#### Provide links to any related discussion on [lines](https://llllllll.co/).
https://llllllll.co/t/ansible-development-and-beta-firmware-discussion/23118/166

#### How should this be manually tested?
Patch Ansible TR 1 to Teletype input 1 and put `X KR.DUR 1` in script 1. Monitor variables in live mode to see `X` change to the trigger duration in milliseconds when Kria reaches a new step.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] run `make format` on each commit
