### PR TITLE
edit mode: dim M when metro inactive, fix out of bounds array access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **NEW**: `LSH` and `RSH` shift the opposite direction when passed a negative shift amount
 - **NEW**: new op: `SGN` (sign of argument)
 - **NEW**: new kria remote op: `KR.DUR`
+- **FIX**: dim M in edit mode when metro inactive
 
 ## v3.1.0
 

--- a/module/edit_mode.c
+++ b/module/edit_mode.c
@@ -401,11 +401,16 @@ uint8_t screen_refresh_edit() {
     u8 sel2 = max(line_no1, line_no2);
 
     if (dirty & D_INPUT) {
+        bool muted = false;
         char prefix = script + '1';
-        if (script == METRO_SCRIPT)
+        if (script == METRO_SCRIPT) {
             prefix = 'M';
+            muted = !scene_state.variables.m_act;
+        }
         else if (script == INIT_SCRIPT)
             prefix = 'I';
+        else if (script <= TT_SCRIPT_8)
+            muted = ss_get_mute(&scene_state, script);
 
         if (sel1 == sel2)
             line_editor_draw(&le, prefix, &line[7]);
@@ -414,7 +419,7 @@ uint8_t screen_refresh_edit() {
 
         char script_no[2] = { prefix, '\0' };
         font_string_region_clip(&line[7], script_no, 0, 0,
-                                ss_get_mute(&scene_state, script) ? 4 : 15, 0);
+                                muted ? 4 : 15, 0);
 
         screen_dirty |= (1 << 7);
         dirty &= ~D_INPUT;

--- a/module/main.c
+++ b/module/main.c
@@ -861,6 +861,8 @@ void tele_metro_updated() {
         set_metro_icon(false);
 
     if (grid_connected && grid_control_mode) scene_state.grid.grid_dirty = 1;
+
+    edit_mode_refresh();
 }
 
 void tele_metro_reset() {


### PR DESCRIPTION
#### What does this PR do?

When `M.ACT` is 0, dim the `M` in the line editor prompt on the metro script, to match muted scripts. Also fix an out-of-bounds array access that I don't think was causing any trouble but could make this feature behave incorrectly when new members are added to `scene_variables_t` in the future.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-3-feature-requests-and-discussion/16219/408?u=csboling

#### How should this be manually tested?

While editing the metro script, use CTRL+F9 to toggle the metro on and off, and see the `M` dim to match the brightness of muted scripts. The same behavior is seen when running `M.ACT FLIP` manually.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] run `make format` on each commit
