### PR TITLE
initialize fb min max values

### DIFF
--- a/module/flash.c
+++ b/module/flash.c
@@ -82,7 +82,14 @@ void flash_prepare() {
             flash_write(i, &scene, &text);
         }
 
-        cal_data_t cal = { 0, 16383, 0, 16383 };
+        cal_data_t cal = { 0,
+                           16383,
+                           0,
+                           16383,
+                           { 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0 },
+                           { 16383, 16383, 16383, 16383, 16383, 16383, 16383,
+                             16383, 16383, 16383, 16383, 16383, 16383, 16383,
+                             16383, 16383 } };
         flashc_memcpy((void *)&f.cal, &cal, sizeof(cal), true);
         device_config_t device_config = {.flip = 0 };
         flashc_memcpy((void *)&f.device_config, &device_config,


### PR DESCRIPTION
#### What does this PR do?

initialize min and max values for the `FADER` op so that they aren't garbage prior to first calibration

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-3-2-0-release/31530/32?u=discohead

#### How should this be manually tested?

need TT with clean flash and a Faderbank, before calibrating the `FADER` op the values should at least be sensible

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] run `make format` on each commit
