### PR TITLE
fix for #172

### DIFF
--- a/module/usb_disk_mode.c
+++ b/module/usb_disk_mode.c
@@ -242,8 +242,8 @@ void tele_usb_disk() {
                     uint8_t p = 0;
                     int8_t s = 99;
                     uint8_t b = 0;
-                    uint16_t num = 0;
-                    int8_t neg = 1;
+                    int16_t num = 0;
+                    int16_t neg = 1;
 
                     char input[32];
                     memset(input, 0, sizeof(input));


### PR DESCRIPTION
#### What does this PR do?

fixes issue #172 (negative pattern values incorrect after USB read)

#### How should this be manually tested?

place some negative values in a pattern, save to USB, then read from USB. 
test edge cases (-32768, 32767).

#### If the related Github issues aren't referenced in your commits, please link to them here.

issue #172 

#### I have,
* [ ] updated `CHANGELOG.md` - no, will update in a separate checkin once PR 201 is merged
* [ ] updated the documentation - n/a
* [x] run `make format` on each commit
