### PR TITLE
LAST SCRIPT in live mode should give time since I script

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v3.2.x
+
+- **FIX**: `LAST SCRIPT` in live mode gives time since init script was run
+
 ## v3.2.1
 
 - **FIX**: negative pattern values are properly read from USB

--- a/docs/ops/variables.toml
+++ b/docs/ops/variables.toml
@@ -134,13 +134,13 @@ short = "enable or disable timer counting, default `1`"
 [LAST]
 prototype = "LAST x"
 short = "get value in milliseconds since last script run time"
-description = """ 
-Gets the number of milliseconds since the current script was run.  From the live mode, shows time elapsed since last run of I script.
+description = """
+Gets the number of milliseconds since the given script was run, where `M` is script 9 and `I` is script 10. From the live mode, `LAST SCRIPT` gives the time elapsed since last run of I script.
 
 For example, one-line tap tempo:
 
 ```
-M LAST SCRIPT 
+M LAST SCRIPT
 ```
 
 Running this script twice will set the metronome to be the time between runs.
@@ -167,7 +167,7 @@ prototype_set = "J x"
 short = """get / set the variable `J`"""
 description="""
 get / set the variable `J`, each script gets its own `J` variable, so if you call
-a script from another script you can still use and modify `J` without affecting the calling script. 
+a script from another script you can still use and modify `J` without affecting the calling script.
 """
 
 [K]
@@ -176,6 +176,5 @@ prototype_set = "K x"
 short = """get / set the variable `K`"""
 description="""
 get / set the variable `K`, each script gets its own `K` variable, so if you call
-a script from another script you can still use and modify `K` without affecting the calling script. 
+a script from another script you can still use and modify `K` without affecting the calling script.
 """
-

--- a/src/ops/variables.c
+++ b/src/ops/variables.c
@@ -101,6 +101,13 @@ static void op_TIME_ACT_set(const void *NOTUSED(data), scene_state_t *ss,
 static void op_LAST_get(const void *NOTUSED(data), scene_state_t *ss,
                         exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t script_number = cs_pop(cs) - 1;
+
+    // when run in LIVE mode, SCRIPT will be 0.
+    // LIVE SCRIPT should give time since INIT
+    // was run in this case.
+    if (script_number < 1) {
+        script_number = 9;
+    }
     int16_t last = ss_get_script_last(ss, script_number);
     cs_push(cs, last);
 }
@@ -192,4 +199,3 @@ static void op_K_set(const void *NOTUSED(data), scene_state_t *ss,
     int16_t sn = es_variables(es)->script_number;
     ss->variables.k[sn] = cs_pop(cs);
 }
-


### PR DESCRIPTION
#### What does this PR do?

Previously running `LAST SCRIPT` in live mode was equivalent to running `LAST 0` - since there is no script 0, this would always return 0. Changes this so that it gives the time since the init script was run, since this matches the documentation.

#### How should this be manually tested?

Use `LAST SCRIPT` in live mode to check the time. Press F10 to trigger the init script manually and check again.

#### If the related Github issues aren't referenced in your commits, please link to them here.

Fixes #193 


#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] run `make format` on each commit
