### PR TITLE
Add DEL.G exponential delay

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **FIX**: negative pattern values are properly read from USB
 - **NEW**: generic i2c ops: `IIA`, `IIS..`, `IIQ..`, `IIB..`
+- **NEW**: exponential delay operator `DEL.G`
 
 ## v3.2.0
 

--- a/docs/ops/delay.toml
+++ b/docs/ops/delay.toml
@@ -28,3 +28,11 @@ Delay the command following the colon once immediately, and `x - 1` times at int
 The buffer can hold up to 16 commands. If the buffer is full, additional commands
 will be discarded.
 """
+["DEL.G"]
+prototype = "DEL.R x delay_time num denom: ..."
+short = "Trigger the command once immediately and `x - 1` times at ms intervals of `delay_time * (num/denom)^n` where n ranges from 0 to `x - 1`."
+description = """
+Trigger the command once immediately and `x - 1` times at ms intervals of `delay_time * (num/denom)^n` where n ranges from 0 to `x - 1` by placing it into a buffer. 
+The buffer can hold up to 16 commands. If the buffer is full, additional commands
+will be discarded.
+"""

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,4 +1,6 @@
 # Updates
+## v3.2.2
+- **NEW**: exponential delay operator `DEL.G`
 
 ## v3.2.1
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,11 +1,10 @@
 # Updates
-## v3.2.2
-- **NEW**: exponential delay operator `DEL.G`
 
 ## v3.2.1
 
 - **FIX**: negative pattern values are properly read from USB
 - **NEW**: generic i2c ops: `IIA`, `IIS..`, `IIQ..`, `IIB..`
+- **NEW**: exponential delay operator `DEL.G`
 
 ## v3.2.0
 

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -327,7 +327,7 @@ const char* help5[HELP5_LENGTH] = { "5/14 OPERATORS",
                                     "TR.TOG X|FLIP STATE OF TR X",
                                     "TR.PULSE X|PULSE TR X" };
 
-#define HELP6_LENGTH 38
+#define HELP6_LENGTH 42
 const char* help6[HELP6_LENGTH] = { "6/14 PRE :",
                                     " ",
                                     "EACH PRE NEEDS A : FOLLOWED",
@@ -344,6 +344,10 @@ const char* help6[HELP6_LENGTH] = { "6/14 PRE :",
                                     "  SAME AS DEL.X BUT",
                                     "  EXECUTE ONCE IMMEDIATELY",
                                     "  THEN A-1 TIMES",
+                                    "DEL.G A B C D: |EXPO DELAY",
+                                    "  SAME AS DEL.R BUT TIME",
+                                    "  BETWEEN EACH REPEAT",
+                                    "  SCALED RECURSIVELY BY C/D",
                                     " ",
                                     "S: |PUSH ONTO STACK",
                                     "S.CLR|CLEAR S",

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -664,6 +664,7 @@
         "DEL"         => { MATCH_MOD(E_MOD_DEL); };
         "DEL.X"       => { MATCH_MOD(E_MOD_DEL_X); };
         "DEL.R"       => { MATCH_MOD(E_MOD_DEL_R); };
+        "DEL.G"       => { MATCH_MOD(E_MOD_DEL_G); };
 
         # matrixarchate
         "MA.SELECT"   => { MATCH_OP(E_OP_MA_SELECT); };

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -142,9 +142,9 @@ static void mod_DEL_G_func(scene_state_t *ss, exec_state_t *es,
            delay_common_add(ss, es, delay_time_next, post_command)) {
         // increment delay time for next delay
         // normalise incremented value to stop negative wrap from increment
-        delay_time = (delay_time * delay_mult_num) / delay_mult_denom;
         delay_time_next += delay_time;
         delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
+        delay_time = (delay_time * delay_mult_num) / delay_mult_denom;
 
         num_delays--;
     }

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -23,10 +23,15 @@ static void mod_DEL_R_func(scene_state_t *ss, exec_state_t *es,
                            command_state_t *cs,
                            const tele_command_t *post_command);
 
+static void mod_DEL_G_func(scene_state_t *ss, exec_state_t *es,
+                           command_state_t *cs,
+                           const tele_command_t *post_command);
+
 const tele_mod_t mod_DEL = MAKE_MOD(DEL, mod_DEL_func, 1);
 const tele_op_t op_DEL_CLR = MAKE_GET_OP(DEL.CLR, op_DEL_CLR_get, 0, false);
 const tele_mod_t mod_DEL_X = MAKE_MOD(DEL.X, mod_DEL_X_func, 2);
 const tele_mod_t mod_DEL_R = MAKE_MOD(DEL.R, mod_DEL_R_func, 2);
+const tele_mod_t mod_DEL_G = MAKE_MOD(DEL.G, mod_DEL_G_func, 4);
 
 // common code to queue a delay shared between all delay ops
 // NOTE it is the responsibility of the callee to call tele_has_delays
@@ -110,6 +115,34 @@ static void mod_DEL_R_func(scene_state_t *ss, exec_state_t *es,
            delay_common_add(ss, es, delay_time_next, post_command)) {
         // increment delay time for next delay
         // normalise incremented value to stop negative wrap from increment
+        delay_time_next += delay_time;
+        delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
+
+        num_delays--;
+    }
+
+    tele_has_delays(ss->delay.count > 0);
+}
+
+static void mod_DEL_G_func(scene_state_t *ss, exec_state_t *es,
+                           command_state_t *cs,
+                           const tele_command_t *post_command) {
+    int16_t num_delays = cs_pop(cs);
+    int16_t delay_time = cs_pop(cs);
+    int16_t delay_mult_num = cs_pop(cs);
+    int16_t delay_mult_denom = cs_pop(cs);
+    int16_t delay_time_next;
+
+    if (delay_time < 1) delay_time = 1;
+
+    // set first delay time to 1ms to trigger immediately
+    delay_time_next = 1;
+
+    while (num_delays > 0 &&
+           delay_common_add(ss, es, delay_time_next, post_command)) {
+        // increment delay time for next delay
+        // normalise incremented value to stop negative wrap from increment
+        delay_time = (delay_time * delay_mult_num) / delay_mult_denom;
         delay_time_next += delay_time;
         delay_time_next = normalise_value(1, 32767, 1, delay_time_next);
 

--- a/src/ops/delay.h
+++ b/src/ops/delay.h
@@ -7,5 +7,6 @@ extern const tele_mod_t mod_DEL;
 extern const tele_op_t op_DEL_CLR;
 extern const tele_mod_t mod_DEL_X;
 extern const tele_mod_t mod_DEL_R;
+extern const tele_mod_t mod_DEL_G;
 
 #endif

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -234,7 +234,7 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     &mod_OTHER, &mod_PROB,
 
     // delay
-    &mod_DEL, &mod_DEL_X, &mod_DEL_R,
+    &mod_DEL, &mod_DEL_X, &mod_DEL_R, &mod_DEL_G,
 
     // pattern
     &mod_P_MAP, &mod_PN_MAP,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -600,6 +600,7 @@ typedef enum {
     E_MOD_DEL,
     E_MOD_DEL_X,
     E_MOD_DEL_R,
+    E_MOD_DEL_G,
     E_MOD_P_MAP,
     E_MOD_PN_MAP,
     E_MOD_S,


### PR DESCRIPTION
#### What does this PR do?
Adds new variant of `DEL.R/X` called `DEL.G`. It operates in the same way as `DEL.R`, but each successive repeat is multiplied by the fraction given in the argument. This allows easy creation of bouncing balls and other interesting rhythmic effects. 

The implementation is largely based on the previous work done for `DEL.R/X`.
#### Provide links to any related discussion on [lines](https://llllllll.co/).
https://llllllll.co/t/teletype-3-2-feature-requests-and-discussions/32052/39?u=jngpng
#### How should this be manually tested?
Try `DEL.G` with a variety of settings. `DEL.G 10 100 2 3: TR.P 1` should produce a bouncing-ball pattern. `DEL.G 10 100 5 4: TR.P 1` should produce something like a trill or roll.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [ ] run `make format` on each commit - is it possible to do this when using the Docker-based build chain rather than a local build-chain?
