### PR TITLE
ability to specify numbers in binary and hex formats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,14 +1,12 @@
 # Changelog
 
-## v3.2.x
-
-- **FIX**: `LAST SCRIPT` in live mode gives time since init script was run
-
 ## v3.2.1
 
+- **FIX**: `LAST SCRIPT` in live mode gives time since init script was run
 - **FIX**: negative pattern values are properly read from USB
 - **NEW**: generic i2c ops: `IIA`, `IIS..`, `IIQ..`, `IIB..`
 - **NEW**: exponential delay operator `DEL.G`
+- **NEW**: binary and hex format for numbers: `B...`, `X...`
 
 ## v3.2.0
 

--- a/docs/ops/delay.toml
+++ b/docs/ops/delay.toml
@@ -29,7 +29,7 @@ The buffer can hold up to 16 commands. If the buffer is full, additional command
 will be discarded.
 """
 ["DEL.G"]
-prototype = "DEL.R x delay_time num denom: ..."
+prototype = "DEL.G x delay_time num denom: ..."
 short = "Trigger the command once immediately and `x - 1` times at ms intervals of `delay_time * (num/denom)^n` where n ranges from 0 to `x - 1`."
 description = """
 Trigger the command once immediately and `x - 1` times at ms intervals of `delay_time * (num/denom)^n` where n ranges from 0 to `x - 1` by placing it into a buffer. 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2,9 +2,11 @@
 
 ## v3.2.1
 
+- **FIX**: `LAST SCRIPT` in live mode gives time since init script was run
 - **FIX**: negative pattern values are properly read from USB
 - **NEW**: generic i2c ops: `IIA`, `IIS..`, `IIQ..`, `IIB..`
 - **NEW**: exponential delay operator `DEL.G`
+- **NEW**: binary and hex format for numbers: `B...`, `X...`
 
 ## v3.2.0
 

--- a/src/scanner.rl
+++ b/src/scanner.rl
@@ -29,6 +29,7 @@ error_t scanner(const char *data, tele_command_t *out,
     const char* pe = data + len;  // pointer to end of data
     const char* eof = pe;         // pointer to eof
     (void)scanner_en_main;        // fix unused variable warning
+    (void)act;                    // fix unused variable warning
 
     // reset outputs
     error_msg[0] = 0;


### PR DESCRIPTION
#### What does this PR do?

adds ability to specify numbers in binary and hex format. binary numbers must start with `B` prefix, hex - with `X` prefix. negative numbers in binary/hex not supported (not likely to be used for negative numbers i think).

also fixed warnings for tests and simulator builds and fixed a typo for `DEL.G` op.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-3-2-feature-requests-and-discussions/32052/81

#### How should this be manually tested?

try various numbers

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [ ] run `make format` on each commit
