### PR TITLE
improve performance when navigating in docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - **FIX**: `LAST SCRIPT` in live mode gives time since init script was run
 - **FIX**: negative pattern values are properly read from USB
+- **FIX**: delay when navigating to sections in docs
 - **NEW**: generic i2c ops: `IIA`, `IIS..`, `IIQ..`, `IIB..`
 - **NEW**: exponential delay operator `DEL.G`
 - **NEW**: binary and hex format for numbers: `B...`, `X...`

--- a/utils/templates/template.html
+++ b/utils/templates/template.html
@@ -73,13 +73,13 @@
         <svg style="display: none;">
             <symbol id="custom-hamburger-icon" viewBox="0 0 22 17"
                 xmlns="http://www.w3.org/2000/svg">
-                    <g 
+                    <g
                         id="Page-1"
                         stroke-width="1"
                         fill="none"
                         fill-rule="evenodd"
                         stroke-linecap="round">
-                            <g 
+                            <g
                                 id="Artboard"
                                 transform="translate(-180.000000, -130.000000)"
                                 stroke-width="2">
@@ -209,17 +209,17 @@
                                 navElements[j]
                                     .classList
                                     .add("NavigationArea-navLi--closed");
-                    } else if (!parentHrefClicked && 
-                        hrefClicked && 
+                    } else if (!parentHrefClicked &&
+                        hrefClicked &&
                         navElements[j]
                             .classList
-                            .contains("NavigationArea-navLi--secondary") && 
+                            .contains("NavigationArea-navLi--secondary") &&
                         navElements[j]
                             .getAttribute("active-parent-anchor") !== hrefClicked) {
                                 navElements[j]
                                     .classList
                                     .add("NavigationArea-navLi--closed");
-                    } else if (parentHrefClicked && 
+                    } else if (parentHrefClicked &&
                         navElements[j]
                             .getAttribute("active-parent-anchor") === parentHrefClicked) {
                                 navElements[j]
@@ -272,6 +272,23 @@
                 }
             };
 
+            var showMainContent = function () {
+                // for phone-size screens, navigation pane should
+                // hide as soon as a nav element is clicked
+                if (window.innerWidth < 700) {
+                    hidden = false;
+                    toggleNavigationArea();
+                }
+
+                // don't show main content until after all navigation changes have
+                // been made to make sure hash links navigate to the right place
+                document.getElementsByClassName("Content-inner")[0]
+                    .classList.remove("Content-inner--hidden");
+                if (window.location.hash) {
+                    window.location = window.location.hash;
+                }
+            }
+
             // handler for navigating to a new nav link
             var navToSection = function () {
                 // All non-internal links should open new tab/window
@@ -310,21 +327,7 @@
                     }
                 };
 
-                // for phone-size screens, navigation pane should 
-                // hide as soon as a nav element is clicked
-                if (window.innerWidth < 700) {
-                    hidden = false;
-                    toggleNavigationArea();
-                }
-
-                // don't show main content until after all navigation changes have
-                // been made to make sure hash links navigate to the right place
-                document.getElementsByClassName("Content-inner")[0]
-                    .classList.remove("Content-inner--hidden");
-                if (window.location.hash) {
-                    window.location = window.location.hash;
-                }
-
+                showMainContent();
                 linksToNewTab();
                 fixBr();
             };
@@ -332,7 +335,7 @@
             // this makes back button work for navigating between links
             var changedHashHandler = function () {
                 updateAnchor();
-                navToSection();
+                showMainContent();
             };
 
             var navActionContainer = document


### PR DESCRIPTION
#### What does this PR do?

Previously, the `onchangehash` handler would run `fixBr` every time
the user navigated to a new hash. The `fixBr` function takes a long
time to execute because it causes lots of reflows. This commit
removes the (seemingly) unnecessary `linksToNewTab` and `fixBr` function calls
from the onhashchange handler by moving the necessary code to a new helper
function.

#### How should this be manually tested?

1. Build docs
2. Open `teletype.html`
3. Navigate to various sections in the navigation pane (should be almost instant now)
4. Try navigating backward/forward in the browser

#### I have,
* [X] updated `CHANGELOG.md`
* [X] updated the documentation
* [X] run `make format` on each commit
