### PR TITLE
fix for "LAST n is broken for script 1"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@
 - **NEW**: exponential delay operator `DEL.G`
 - **NEW**: binary and hex format for numbers: `B...`, `X...`
 - **NEW**: Disting EX ops
+- **FIX**: `LAST n` is broken for script 1
 
 ## v3.2.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -9,6 +9,7 @@
 - **NEW**: exponential delay operator `DEL.G`
 - **NEW**: binary and hex format for numbers: `B...`, `X...`
 - **NEW**: Disting EX ops
+- **FIX**: `LAST n` is broken for script 1
 
 ## v3.2.0
 

--- a/src/ops/variables.c
+++ b/src/ops/variables.c
@@ -105,7 +105,7 @@ static void op_LAST_get(const void *NOTUSED(data), scene_state_t *ss,
     // when run in LIVE mode, SCRIPT will be 0.
     // LIVE SCRIPT should give time since INIT
     // was run in this case.
-    if (script_number < 1) {
+    if (script_number < 0) {
         script_number = 9;
     }
     int16_t last = ss_get_script_last(ss, script_number);


### PR DESCRIPTION
#### What does this PR do?

fixes issue #222

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-3-2-feature-requests-and-discussions/32052/161

#### How should this be manually tested?

add this to script 1: `A LAST SCRIPT`, switch to live screen, trigger script 1 and watch variable `A`. it should reset count each time it's called.

#### If the related Github issues aren't referenced in your commits, please link to them here.

https://github.com/monome/teletype/issues/222

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] run `make format` on each commit
