### PR TITLE
fix for X and B not working for negative values, formatting

### DIFF
--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -803,9 +803,19 @@
     {                                                    \
         out->tag = NUMBER;                               \
         uint8_t base = 0;                                \
-        if (token[0] == 'X') { base = 16; token++; }     \
-        else if (token[0] == 'B') { base = 2; token++; } \
+        uint8_t binhex = 0;                              \
+        if (token[0] == 'X') {                           \
+            binhex = 1;                                  \
+            base = 16;                                   \
+            token++;                                     \
+        }                                                \
+        else if (token[0] == 'B') {                      \
+            binhex = 1;                                  \
+            base = 2;                                    \
+            token++;                                     \
+        }                                                \
         int32_t val = strtol(token, NULL, base);         \
+        if (binhex) val = (int16_t)((uint16_t)val);      \
         val = val > INT16_MAX ? INT16_MAX : val;         \
         val = val < INT16_MIN ? INT16_MIN : val;         \
         out->value = val;                                \

--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -160,24 +160,21 @@ static void mod_DEL_G_func(scene_state_t *ss, exec_state_t *es,
 static void mod_DEL_B_func(scene_state_t *ss, exec_state_t *es,
                            command_state_t *cs,
                            const tele_command_t *post_command) {
-
     int16_t base_time = cs_pop(cs);
-	if (base_time < 1) base_time = 1;
-	int16_t mask = cs_pop(cs);
-	
+    if (base_time < 1) base_time = 1;
+    int16_t mask = cs_pop(cs);
+
     int16_t delay_time_next = 1;
 
-	for (uint8_t i = 0; i <= 15; i++) {
-		if ((mask >> i) & 1) {
-			if (i == 0) {
-				delay_time_next = 1;
-			}
-			else {
-				delay_time_next = normalise_value(1, 32767, 0, i * base_time);
-			}
-			delay_common_add(ss, es, delay_time_next, post_command);
-		}
-	}
+    for (uint8_t i = 0; i <= 15; i++) {
+        if ((mask >> i) & 1) {
+            if (i == 0) { delay_time_next = 1; }
+            else {
+                delay_time_next = normalise_value(1, 32767, 0, i * base_time);
+            }
+            delay_common_add(ss, es, delay_time_next, post_command);
+        }
+    }
 
     tele_has_delays(ss->delay.count > 0);
 }

--- a/src/ops/maths.c
+++ b/src/ops/maths.c
@@ -45,11 +45,11 @@ static void op_WRAP_get(const void *data, scene_state_t *ss, exec_state_t *es,
 static void op_QT_get(const void *data, scene_state_t *ss, exec_state_t *es,
                       command_state_t *cs);
 static void op_QT_S_get(const void *data, scene_state_t *ss, exec_state_t *es,
-                      command_state_t *cs);
+                        command_state_t *cs);
 static void op_QT_CS_get(const void *data, scene_state_t *ss, exec_state_t *es,
-                      command_state_t *cs);
+                         command_state_t *cs);
 static void op_QT_B_get(const void *data, scene_state_t *ss, exec_state_t *es,
-                      command_state_t *cs);
+                        command_state_t *cs);
 static void op_AVG_get(const void *data, scene_state_t *ss, exec_state_t *es,
                        command_state_t *cs);
 static void op_EQ_get(const void *data, scene_state_t *ss, exec_state_t *es,
@@ -93,13 +93,13 @@ static void op_SCALE_get(const void *data, scene_state_t *ss, exec_state_t *es,
 static void op_N_get(const void *data, scene_state_t *ss, exec_state_t *es,
                      command_state_t *cs);
 static void op_VN_get(const void *data, scene_state_t *ss, exec_state_t *es,
-                     command_state_t *cs);
-static void op_N_S_get(const void *data, scene_state_t *ss, exec_state_t *es,
                       command_state_t *cs);
+static void op_N_S_get(const void *data, scene_state_t *ss, exec_state_t *es,
+                       command_state_t *cs);
 static void op_N_C_get(const void *data, scene_state_t *ss, exec_state_t *es,
-                     command_state_t *cs);
+                       command_state_t *cs);
 static void op_N_CS_get(const void *data, scene_state_t *ss, exec_state_t *es,
-                     command_state_t *cs);
+                        command_state_t *cs);
 static void op_V_get(const void *data, scene_state_t *ss, exec_state_t *es,
                      command_state_t *cs);
 static void op_VV_get(const void *data, scene_state_t *ss, exec_state_t *es,
@@ -417,137 +417,120 @@ static void op_QT_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_QT_S_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
-	
-	int16_t note_in = cs_pop(cs);
+                        exec_state_t *NOTUSED(es), command_state_t *cs) {
+    int16_t note_in = cs_pop(cs);
     int16_t root = cs_pop(cs);
     int16_t scale = cs_pop(cs) % 9;
     if (scale < 0) scale = 9 + scale;
-	
-	note_in = note_in - root;	
-	int16_t octave = (note_in >= 0) ? (note_in / 12) : ((note_in + 1) / 12 - 1);
 
-	if (note_in >= 0) {
-		note_in = note_in % 12;
-	}
-	else {
-		if (note_in % 12 == 0) {
-			note_in = 0;
-		}
-		else {
-			note_in = 12 + (note_in % 12);
-		}
-	}
+    note_in = note_in - root;
+    int16_t octave = (note_in >= 0) ? (note_in / 12) : ((note_in + 1) / 12 - 1);
 
-	int16_t note_out = 0;
-	
-	for (uint8_t i = 0; i < 7; i++) {
-		if (note_in >= table_n_s[scale][i]) note_out = table_n_s[scale][i];
-	}
-	
-	cs_push(cs, normalise_value(-127, 127, 0, 12 * octave + note_out + root));
+    if (note_in >= 0) { note_in = note_in % 12; }
+    else {
+        if (note_in % 12 == 0) { note_in = 0; }
+        else {
+            note_in = 12 + (note_in % 12);
+        }
+    }
+
+    int16_t note_out = 0;
+
+    for (uint8_t i = 0; i < 7; i++) {
+        if (note_in >= table_n_s[scale][i]) note_out = table_n_s[scale][i];
+    }
+
+    cs_push(cs, normalise_value(-127, 127, 0, 12 * octave + note_out + root));
 }
 
 static void op_QT_CS_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
-	
-	int16_t note_in = cs_pop(cs);
+                         exec_state_t *NOTUSED(es), command_state_t *cs) {
+    int16_t note_in = cs_pop(cs);
     int16_t root = cs_pop(cs);
     int16_t scale = cs_pop(cs) % 9;
     if (scale < 0) scale = 9 + scale;
-	
+
     int16_t degree = cs_pop(cs) - 1;
-	int16_t degree_octave = (degree >= 0) ? (degree / 7) : ((degree + 1) / 7 - 1);
-	if (degree >= 0) {
-		degree = degree % 7;
-	}
-	else {
-		if (degree % 7 == 0) {
-			degree = 0;
-		}
-		else {
-			degree = 7 + (degree % 7);
-		}
-	}
-	
-	int16_t voices = normalise_value(1, 7, 0, cs_pop(cs));
-	
-	note_in = note_in - root;	
-	int16_t octave = (note_in >= 0) ? (note_in / 12) : ((note_in + 1) / 12 - 1);
+    int16_t degree_octave =
+        (degree >= 0) ? (degree / 7) : ((degree + 1) / 7 - 1);
+    if (degree >= 0) { degree = degree % 7; }
+    else {
+        if (degree % 7 == 0) { degree = 0; }
+        else {
+            degree = 7 + (degree % 7);
+        }
+    }
 
-	if (note_in >= 0) {
-		note_in = note_in % 12;
-	}
-	else {
-		if (note_in % 12 == 0) {
-			note_in = 0;
-		}
-		else {
-			note_in = 12 + (note_in % 12);
-		}
-	}
+    int16_t voices = normalise_value(1, 7, 0, cs_pop(cs));
 
-	bool quant = false;
-	int16_t max_n_s_val = 0;
-	int16_t n_s_val;
-	int16_t note_out = 0;
-	int16_t dix;
-	
-	for (int8_t i = 0; i < voices; i++) {
-		dix = (2 * i + degree) % 7;
-		n_s_val = table_n_s[scale][dix];
-		if (n_s_val > max_n_s_val) max_n_s_val = n_s_val;
-		if ((note_in >= n_s_val) && (note_out <= n_s_val)){
-			note_out = n_s_val;
-			quant = true;
-		}
-	}
-	
-	if (!quant) note_out = max_n_s_val - 12;
-	
-	cs_push(cs, normalise_value(-127, 127, 0, 12 * (octave + degree_octave) + note_out + root));
+    note_in = note_in - root;
+    int16_t octave = (note_in >= 0) ? (note_in / 12) : ((note_in + 1) / 12 - 1);
+
+    if (note_in >= 0) { note_in = note_in % 12; }
+    else {
+        if (note_in % 12 == 0) { note_in = 0; }
+        else {
+            note_in = 12 + (note_in % 12);
+        }
+    }
+
+    bool quant = false;
+    int16_t max_n_s_val = 0;
+    int16_t n_s_val;
+    int16_t note_out = 0;
+    int16_t dix;
+
+    for (int8_t i = 0; i < voices; i++) {
+        dix = (2 * i + degree) % 7;
+        n_s_val = table_n_s[scale][dix];
+        if (n_s_val > max_n_s_val) max_n_s_val = n_s_val;
+        if ((note_in >= n_s_val) && (note_out <= n_s_val)) {
+            note_out = n_s_val;
+            quant = true;
+        }
+    }
+
+    if (!quant) note_out = max_n_s_val - 12;
+
+    cs_push(cs, normalise_value(-127, 127, 0, 12 * (octave + degree_octave) +
+                                                  note_out + root));
 }
 
 static void op_QT_B_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
-	
-	int16_t note_in = cs_pop(cs);
+                        exec_state_t *NOTUSED(es), command_state_t *cs) {
+    int16_t note_in = cs_pop(cs);
     int16_t root = cs_pop(cs);
     int16_t mask = cs_pop(cs);
-	
-	note_in = note_in - root;
-	int16_t octave = (note_in >= 0) ? (note_in / 12) : ((note_in + 1) / 12 - 1);
 
-	if (note_in >= 0) {
-		note_in = note_in % 12;
-	}
-	else {
-		if (note_in % 12 == 0) {
-			note_in = 0;
-		}
-		else {
-			note_in = 12 + (note_in % 12);
-		}
-	}
+    note_in = note_in - root;
+    int16_t octave = (note_in >= 0) ? (note_in / 12) : ((note_in + 1) / 12 - 1);
 
-	bool quant = false;
-	int16_t b_val = 0;
-	int16_t note_out = 0;
-	
-	for (uint8_t i=0; i<=11; i++) {
-		if ((mask >> i) & 1) {
-			b_val = i;
-			if	(note_in >= b_val) {
-				note_out = b_val;
-				quant = true;
-			}
-		}
-	}
-	
-	if (!quant) note_out = b_val - 12;
-	note_out = 12 * octave + note_out + root;
-	
-	cs_push(cs, normalise_value(-127, 127, 0, note_out));
+    if (note_in >= 0) { note_in = note_in % 12; }
+    else {
+        if (note_in % 12 == 0) { note_in = 0; }
+        else {
+            note_in = 12 + (note_in % 12);
+        }
+    }
+
+    bool quant = false;
+    int16_t b_val = 0;
+    int16_t note_out = 0;
+
+    for (uint8_t i = 0; i <= 11; i++) {
+        if ((mask >> i) & 1) {
+            b_val = i;
+            if (note_in >= b_val) {
+                note_out = b_val;
+                quant = true;
+            }
+        }
+    }
+
+    if (!quant) note_out = b_val - 12;
+    note_out = 12 * octave + note_out + root;
+
+    cs_push(cs, normalise_value(-127, 127, 0, note_out));
 }
 
 static void op_AVG_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
@@ -619,10 +602,13 @@ static uint16_t lrot(uint16_t x, uint8_t n) {
     return (x << n) | (x >> (16 - n));
 }
 
-typedef union { int16_t si; uint16_t ui; } bits16;
+typedef union {
+    int16_t si;
+    uint16_t ui;
+} bits16;
 
 static void op_RROT_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                       exec_state_t *NOTUSED(es), command_state_t *cs) {
+                        exec_state_t *NOTUSED(es), command_state_t *cs) {
     bits16 u;
     u.si = cs_pop(cs);
     int16_t n = cs_pop(cs) % 16;
@@ -631,7 +617,7 @@ static void op_RROT_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_LROT_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                       exec_state_t *NOTUSED(es), command_state_t *cs) {
+                        exec_state_t *NOTUSED(es), command_state_t *cs) {
     bits16 u;
     u.si = cs_pop(cs);
     int16_t n = cs_pop(cs) % 16;
@@ -776,21 +762,21 @@ static void op_N_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_VN_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
+                      exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t v_in = cs_pop(cs);
-	int16_t n_out = 0;
+    int16_t n_out = 0;
 
     if (v_in < 0) {
-		v_in = -v_in;
-		for (int16_t i = 127; i >= 0; i--) {
-			if (v_in <= table_n[i]) n_out = i;
-		}
+        v_in = -v_in;
+        for (int16_t i = 127; i >= 0; i--) {
+            if (v_in <= table_n[i]) n_out = i;
+        }
         cs_push(cs, -n_out);
     }
     else {
-		for (int16_t i = 0; i <= 127; i++) {
-			if (v_in >= table_n[i]) n_out = i;
-		}
+        for (int16_t i = 0; i <= 127; i++) {
+            if (v_in >= table_n[i]) n_out = i;
+        }
         cs_push(cs, n_out);
     }
 }
@@ -832,20 +818,16 @@ static void op_ER_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_NR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
+                      exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t prime = cs_pop(cs) % 32;
-    if (prime < 0)
-        prime = 32 + prime;
+    if (prime < 0) prime = 32 + prime;
     uint16_t rhythm = (uint16_t)table_nr[prime];
     int16_t mask = cs_pop(cs) % 4;
-    if (mask < 0)
-        mask = 4 + mask;
+    if (mask < 0) mask = 4 + mask;
     int16_t factor = cs_pop(cs) % 17;
-    if (factor < 0)
-        factor = 17 + factor;
+    if (factor < 0) factor = 17 + factor;
     int16_t step = cs_pop(cs) % 16;
-    if (step < 0)
-        step = 16 + step;
+    if (step < 0) step = 16 + step;
     if (mask == 1)
         rhythm = rhythm & 0x0F0F;
     else if (mask == 2)
@@ -859,16 +841,12 @@ static void op_NR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_N_S_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
+                       exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t root = cs_pop(cs);
     int16_t scale = cs_pop(cs) % 9;
-    if (scale < 0) {
-        scale = 9 + scale;
-    }
+    if (scale < 0) { scale = 9 + scale; }
     int16_t degree = (cs_pop(cs) - 1) % 7;
-    if (degree < 0) {
-        degree = 7 + degree;
-    }
+    if (degree < 0) { degree = 7 + degree; }
     int16_t transpose = table_n_s[scale][degree];
     if (root < 0) {
         if (root < -127) root = -127;
@@ -882,16 +860,12 @@ static void op_N_S_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_N_C_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
+                       exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t root = cs_pop(cs);
     int16_t chord = cs_pop(cs) % 13;
-    if (chord < 0) {
-        chord = 13 + chord;
-    }
+    if (chord < 0) { chord = 13 + chord; }
     int16_t component = cs_pop(cs) % 4;
-    if (component < 0) {
-        component = 4 + component;
-    }
+    if (component < 0) { component = 4 + component; }
     int16_t transpose = table_n_c[chord][component];
     if (root < 0) {
         if (root < -127) root = -127;
@@ -905,21 +879,15 @@ static void op_N_C_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
 }
 
 static void op_N_CS_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
-                     exec_state_t *NOTUSED(es), command_state_t *cs) {
+                        exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t root = cs_pop(cs);
     int16_t scale = cs_pop(cs) % 9;
-    if (scale < 0) {
-        scale = 9 + scale;
-    }
+    if (scale < 0) { scale = 9 + scale; }
     int16_t scl_deg = (cs_pop(cs) - 1) % 7;
-    if (scl_deg < 0) {
-        scl_deg = 7 + scl_deg;
-    }
+    if (scl_deg < 0) { scl_deg = 7 + scl_deg; }
     int16_t scl_trans = table_n_s[scale][scl_deg];
     int16_t ch_deg = cs_pop(cs) % 4;
-    if (ch_deg < 0) {
-        ch_deg = 4 + ch_deg;
-    }
+    if (ch_deg < 0) { ch_deg = 4 + ch_deg; }
     int16_t ch_trans = table_n_c[table_n_cs[scale][scl_deg]][ch_deg];
     if (root < 0) {
         if (root < -127) root = -127;
@@ -997,8 +965,10 @@ static void op_BTOG_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
                         exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t v = cs_pop(cs);
     int16_t b = cs_pop(cs);
-    if ((v >> b) & 1) cs_push(cs, v & ~(1 << b));
-	else cs_push(cs, v | (1 << b));
+    if ((v >> b) & 1)
+        cs_push(cs, v & ~(1 << b));
+    else
+        cs_push(cs, v | (1 << b));
 }
 
 static void op_CHAOS_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -83,18 +83,18 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     // maths
     &op_ADD, &op_SUB, &op_MUL, &op_DIV, &op_MOD, &op_RAND, &op_RND, &op_RRAND,
     &op_RRND, &op_R, &op_R_MIN, &op_R_MAX, &op_TOSS, &op_MIN, &op_MAX, &op_LIM,
-    &op_WRAP, &op_WRP, &op_QT, &op_QT_S, &op_QT_CS, &op_QT_B, &op_AVG, &op_EQ, &op_NE, &op_LT, &op_GT, &op_LTE,
-    &op_GTE, &op_NZ, &op_EZ, &op_RSH, &op_LSH, &op_LROT, &op_RROT,
-    &op_EXP, &op_ABS, &op_SGN, &op_AND, &op_OR,
-    &op_JI, &op_SCALE, &op_SCL, &op_N, &op_VN, &op_N_S, &op_N_C, &op_N_CS, &op_V, &op_VV, &op_ER, &op_NR, &op_BPM,
-    &op_BIT_OR, &op_BIT_AND, &op_BIT_NOT, &op_BIT_XOR, &op_BSET, &op_BGET,
-    &op_BCLR, &op_BTOG, &op_XOR, &op_CHAOS, &op_CHAOS_R, &op_CHAOS_ALG, &op_SYM_PLUS,
-    &op_SYM_DASH, &op_SYM_STAR, &op_SYM_FORWARD_SLASH, &op_SYM_PERCENTAGE,
-    &op_SYM_EQUAL_x2, &op_SYM_EXCLAMATION_EQUAL, &op_SYM_LEFT_ANGLED,
-    &op_SYM_RIGHT_ANGLED, &op_SYM_LEFT_ANGLED_EQUAL, &op_SYM_RIGHT_ANGLED_EQUAL,
-    &op_SYM_EXCLAMATION, &op_SYM_LEFT_ANGLED_x2, &op_SYM_RIGHT_ANGLED_x2,
-    &op_SYM_LEFT_ANGLED_x3, &op_SYM_RIGHT_ANGLED_x3,
-    &op_SYM_AMPERSAND_x2, &op_SYM_PIPE_x2, &op_TIF,
+    &op_WRAP, &op_WRP, &op_QT, &op_QT_S, &op_QT_CS, &op_QT_B, &op_AVG, &op_EQ,
+    &op_NE, &op_LT, &op_GT, &op_LTE, &op_GTE, &op_NZ, &op_EZ, &op_RSH, &op_LSH,
+    &op_LROT, &op_RROT, &op_EXP, &op_ABS, &op_SGN, &op_AND, &op_OR, &op_JI,
+    &op_SCALE, &op_SCL, &op_N, &op_VN, &op_N_S, &op_N_C, &op_N_CS, &op_V,
+    &op_VV, &op_ER, &op_NR, &op_BPM, &op_BIT_OR, &op_BIT_AND, &op_BIT_NOT,
+    &op_BIT_XOR, &op_BSET, &op_BGET, &op_BCLR, &op_BTOG, &op_XOR, &op_CHAOS,
+    &op_CHAOS_R, &op_CHAOS_ALG, &op_SYM_PLUS, &op_SYM_DASH, &op_SYM_STAR,
+    &op_SYM_FORWARD_SLASH, &op_SYM_PERCENTAGE, &op_SYM_EQUAL_x2,
+    &op_SYM_EXCLAMATION_EQUAL, &op_SYM_LEFT_ANGLED, &op_SYM_RIGHT_ANGLED,
+    &op_SYM_LEFT_ANGLED_EQUAL, &op_SYM_RIGHT_ANGLED_EQUAL, &op_SYM_EXCLAMATION,
+    &op_SYM_LEFT_ANGLED_x2, &op_SYM_RIGHT_ANGLED_x2, &op_SYM_LEFT_ANGLED_x3,
+    &op_SYM_RIGHT_ANGLED_x3, &op_SYM_AMPERSAND_x2, &op_SYM_PIPE_x2, &op_TIF,
 
     // stack
     &op_S_ALL, &op_S_POP, &op_S_CLR, &op_S_L,
@@ -130,18 +130,16 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     &op_OR_ROTS, &op_OR_ROTW, &op_OR_GRST, &op_OR_CVA, &op_OR_CVB,
 
     // ansible
-    &op_ANS_G_LED, &op_ANS_G, &op_ANS_G_P,
-    &op_ANS_A_LED, &op_ANS_A,
-    &op_ANS_APP,
-    &op_KR_PRE, &op_KR_PAT, &op_KR_SCALE, &op_KR_PERIOD, &op_KR_POS,
-    &op_KR_L_ST, &op_KR_L_LEN, &op_KR_RES, &op_KR_CV, &op_KR_MUTE, &op_KR_TMUTE,
-    &op_KR_CLK, &op_KR_PG, &op_KR_CUE, &op_KR_DIR, &op_KR_DUR,
-    &op_ME_PRE, &op_ME_RES, &op_ME_STOP, &op_ME_SCALE,
-    &op_ME_PERIOD, &op_ME_CV, &op_LV_PRE, &op_LV_RES, &op_LV_POS, &op_LV_L_ST,
-    &op_LV_L_LEN, &op_LV_L_DIR, &op_LV_CV, &op_CY_PRE, &op_CY_RES, &op_CY_POS,
-    &op_CY_REV, &op_CY_CV, &op_MID_SHIFT, &op_MID_SLEW, &op_ARP_STY,
-    &op_ARP_HLD, &op_ARP_RPT, &op_ARP_GT, &op_ARP_DIV, &op_ARP_RES,
-    &op_ARP_SHIFT, &op_ARP_SLEW, &op_ARP_FIL, &op_ARP_ROT, &op_ARP_ER,
+    &op_ANS_G_LED, &op_ANS_G, &op_ANS_G_P, &op_ANS_A_LED, &op_ANS_A,
+    &op_ANS_APP, &op_KR_PRE, &op_KR_PAT, &op_KR_SCALE, &op_KR_PERIOD,
+    &op_KR_POS, &op_KR_L_ST, &op_KR_L_LEN, &op_KR_RES, &op_KR_CV, &op_KR_MUTE,
+    &op_KR_TMUTE, &op_KR_CLK, &op_KR_PG, &op_KR_CUE, &op_KR_DIR, &op_KR_DUR,
+    &op_ME_PRE, &op_ME_RES, &op_ME_STOP, &op_ME_SCALE, &op_ME_PERIOD, &op_ME_CV,
+    &op_LV_PRE, &op_LV_RES, &op_LV_POS, &op_LV_L_ST, &op_LV_L_LEN, &op_LV_L_DIR,
+    &op_LV_CV, &op_CY_PRE, &op_CY_RES, &op_CY_POS, &op_CY_REV, &op_CY_CV,
+    &op_MID_SHIFT, &op_MID_SLEW, &op_ARP_STY, &op_ARP_HLD, &op_ARP_RPT,
+    &op_ARP_GT, &op_ARP_DIV, &op_ARP_RES, &op_ARP_SHIFT, &op_ARP_SLEW,
+    &op_ARP_FIL, &op_ARP_ROT, &op_ARP_ER,
 
     // justfriends
     &op_JF_TR, &op_JF_RMODE, &op_JF_RUN, &op_JF_SHIFT, &op_JF_VTR, &op_JF_MODE,
@@ -196,7 +194,8 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
 
     // fader
     &op_FADER, &op_FADER_SCALE, &op_FADER_CAL_MIN, &op_FADER_CAL_MAX,
-    &op_FADER_CAL_RESET, &op_FB, &op_FB_S, &op_FB_C_MIN, &op_FB_C_MAX, &op_FB_C_R,
+    &op_FADER_CAL_RESET, &op_FB, &op_FB_S, &op_FB_C_MIN, &op_FB_C_MAX,
+    &op_FB_C_R,
 
     // ER301
     &op_SC_TR, &op_SC_TR_TOG, &op_SC_TR_PULSE, &op_SC_TR_TIME, &op_SC_TR_POL,
@@ -263,7 +262,7 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
 
     // stack
     &mod_S,
-    
+
     // disting ex
     &mod_EX1, &mod_EX2, &mod_EX3, &mod_EX4
 };


### PR DESCRIPTION
#### What does this PR do?

- a fix for `X...` and `B...` number formats not producing correct values for numbers 0x8000 and higher.
- ran clang-format on files changed in https://github.com/monome/teletype/pull/225

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-3-2-feature-requests-and-discussions/32052/194

#### How should this be manually tested?

try inputting hex numbers in the range of 0x8000 or higher
try inputting binary numbers in the range 0b1000000000000000 or higher

#### I have,
* [ ] updated `CHANGELOG.md`
* [ ] updated the documentation
* [x] run `make format` on each commit