### PR TITLE
Adds title frontmatter to docs for HMTL metadata

### DIFF
--- a/docs/intro.md
+++ b/docs/intro.md
@@ -1,3 +1,7 @@
+---
+title: teletype - manual
+---
+
 # Introduction
 
 Teletype is a dynamic, musical event triggering platform.

--- a/utils/templates/template.html
+++ b/utils/templates/template.html
@@ -52,24 +52,6 @@
             $include-before$
         $endfor$
 
-        $if(title)$
-            <header>
-                <h1 class="title">$title$</h1>
-
-                $if(subtitle)$
-                    <p class="subtitle">$subtitle$</p>
-                $endif$
-
-                $for(author)$
-                    <p class="author">$author$</p>
-                $endfor$
-
-                $if(date)$
-                    <p class="date">$date$</p>
-                $endif$
-            </header>
-        $endif$
-
         <svg style="display: none;">
             <symbol id="custom-hamburger-icon" viewBox="0 0 22 17"
                 xmlns="http://www.w3.org/2000/svg">


### PR DESCRIPTION
Adds title metadata for generated HTML documentation. Deletes HTML chunk which displays metadata on the page, hidden behind the menu, and not rendered when the title is not set

Tested it working on a local build
I already made a PR here https://github.com/monome/docs/pull/271 before learning they were generated. 
