### PR TITLE
preserve number format

### DIFF
--- a/src/command.c
+++ b/src/command.c
@@ -82,19 +82,19 @@ void print_command(const tele_command_t *cmd, char *out) {
                 break;
             }
             case XNUMBER: {
-                char number[5];
+                char number[6];
                 itoa_hex(value, number);
                 strcat(out, number);
                 break;
             }
             case BNUMBER: {
-                char number[17];
+                char number[18];
                 itoa_bin(value, number);
                 strcat(out, number);
                 break;
             }
             case RNUMBER: {
-                char number[17];
+                char number[18];
                 itoa_rbin(value, number);
                 strcat(out, number);
                 break;

--- a/src/command.c
+++ b/src/command.c
@@ -17,6 +17,56 @@ void copy_post_command(tele_command_t *dst, const tele_command_t *src) {
            dst->length * sizeof(tele_data_t));
 }
 
+static void itoa_hex(uint16_t value, char *out) {
+    static char num[] = "0123456789ABCDEF";
+
+    out[0] = 'X';
+    uint8_t v, index = 1, dont_ignore_zeros = 0;
+
+    for (int8_t i = 3; i >= 0; i--) {
+        v = (value >> (i << 2)) & 0xf;
+        if (dont_ignore_zeros || v) {
+            out[index++] = num[v];
+            dont_ignore_zeros = 1;
+        }
+    }
+
+    if (!dont_ignore_zeros) out[index++] = '0';
+    out[index] = '\0';
+}
+
+static void itoa_bin(uint16_t value, char *out) {
+    out[0] = 'B';
+    uint8_t v, index = 1, dont_ignore_zeros = 0;
+
+    for (int8_t i = 15; i >= 0; i--) {
+        v = (value >> i) & 1;
+        if (dont_ignore_zeros || v) {
+            out[index++] = '0' + v;
+            dont_ignore_zeros = 1;
+        }
+    }
+
+    if (!dont_ignore_zeros) out[index++] = '0';
+    out[index] = '\0';
+}
+
+static void itoa_rbin(uint16_t value, char *out) {
+    out[0] = 'R';
+    uint8_t v, index = 1, dont_ignore_zeros = 0;
+
+    for (int8_t i = 0; i < 16; i++) {
+        v = (value >> i) & 1;
+        if (dont_ignore_zeros || v) {
+            out[index++] = '0' + v;
+            dont_ignore_zeros = 1;
+        }
+    }
+
+    if (!dont_ignore_zeros) out[index++] = '0';
+    out[index] = '\0';
+}
+
 void print_command(const tele_command_t *cmd, char *out) {
     out[0] = 0;
     for (size_t i = 0; i < cmd->length; i++) {
@@ -28,6 +78,24 @@ void print_command(const tele_command_t *cmd, char *out) {
             case NUMBER: {
                 char number[8];
                 itoa(value, number, 10);
+                strcat(out, number);
+                break;
+            }
+            case XNUMBER: {
+                char number[5];
+                itoa_hex(value, number);
+                strcat(out, number);
+                break;
+            }
+            case BNUMBER: {
+                char number[17];
+                itoa_bin(value, number);
+                strcat(out, number);
+                break;
+            }
+            case RNUMBER: {
+                char number[17];
+                itoa_rbin(value, number);
                 strcat(out, number);
                 break;
             }

--- a/src/command.h
+++ b/src/command.h
@@ -6,7 +6,16 @@
 
 #define COMMAND_MAX_LENGTH 16
 
-typedef enum { NUMBER, OP, MOD, PRE_SEP, SUB_SEP } tele_word_t;
+typedef enum {
+    NUMBER,
+    XNUMBER,
+    BNUMBER,
+    RNUMBER,
+    OP,
+    MOD,
+    PRE_SEP,
+    SUB_SEP
+} tele_word_t;
 
 typedef struct {
     tele_word_t tag;

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -862,11 +862,13 @@
         uint8_t binhex = 0;                              \
         uint8_t bitrev = 0;                              \
         if (token[0] == 'X') {                           \
+            out->tag = XNUMBER;                          \
             binhex = 1;                                  \
             base = 16;                                   \
             token++;                                     \
         }                                                \
         else if (token[0] == 'B') {                      \
+            out->tag = BNUMBER;                          \
             binhex = 1;                                  \
             base = 2;                                    \
             token++;                                     \

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -874,6 +874,7 @@
             token++;                                     \
         }                                                \
         else if (token[0] == 'R') {                      \
+            out->tag = RNUMBER;                          \
             binhex = 1;                                  \
             bitrev = 1;                                  \
             base = 2;                                    \

--- a/src/teletype.c
+++ b/src/teletype.c
@@ -57,7 +57,10 @@ error_t validate(const tele_command_t *c,
         bool first_cmd = idx == 0 || c->data[idx - 1].tag == PRE_SEP ||
                          c->data[idx - 1].tag == SUB_SEP;
 
-        if (word_type == NUMBER) { stack_depth++; }
+        if (word_type == NUMBER || word_type == XNUMBER ||
+            word_type == BNUMBER || word_type == RNUMBER) {
+            stack_depth++;
+        }
         else if (word_type == OP) {
             const tele_op_t *op = tele_ops[word_value];
 
@@ -260,7 +263,10 @@ process_result_t process_command(scene_state_t *ss, exec_state_t *es,
             const tele_word_t word_type = c->data[idx].tag;
             const int16_t word_value = c->data[idx].value;
 
-            if (word_type == NUMBER) { cs_push(&cs, word_value); }
+            if (word_type == NUMBER || word_type == XNUMBER ||
+                word_type == BNUMBER || word_type == RNUMBER) {
+                cs_push(&cs, word_value);
+            }
             else if (word_type == OP) {
                 const tele_op_t *op = tele_ops[word_value];
 


### PR DESCRIPTION
#### What does this PR do?

previously, numbers entered using `X..` | `B..` | `R..` formats would get converted to decimal whenever a line containing them would be entered. with this change the number format will be preserved.

#### How should this be manually tested?

ensure number formats are preserved when:
- entering them in live screen and then using history
- entering numbers in script editing
- storing scenes to USB and restoring them from USB

test `X0`, `B0`, `R0`.

#### I have,
* [ ] updated `CHANGELOG.md` - no need, it restores expected functionality
* [ ] updated the documentation - no need, it restores expected functionality
* [x] run `make format` on each commit
