### PR TITLE
W/2.0 cleanup

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,8 @@
 - **NEW**: binary scale ops `N.B` and `N.BX`
 - **NEW**: reverse binary for numbers: `R...`
 - **NEW**: reverse binary OP: `BREV`
+- **FIX**: most of one argument W/2.0 ops will now return value when called without args
+- **NEW**: W/2.0 ops documentation
 
 ## v3.2.0
 

--- a/docs/ops/wslashdelay.md
+++ b/docs/ops/wslashdelay.md
@@ -1,0 +1,5 @@
+## W/2.0 delay
+Delay mode of W/ eurorack module.
+
+More extensively covered in the [W/ Documentation](https://www.whimsicalraps.com/pages/w-type).
+

--- a/docs/ops/wslashdelay.toml
+++ b/docs/ops/wslashdelay.toml
@@ -1,0 +1,63 @@
+["W/D.FBK"]
+prototype = "W/D.FBK level"
+short = "amount of feedback from read head to write head (s16V)"
+
+["W/D.MIX"]
+prototype = "W/D.MIX fade"
+short = "fade from dry to delayed signal"
+
+["W/D.LPASS"]
+prototype = "W/D.LPASS cutoff"
+short = "centre frequency of filter in feedback loop (s16V)"
+
+["W/D.FREEZE"]
+prototype = "W/D.FREEZE is_active"
+short = "deactivate record head to freeze the current buffer (s8)"
+
+["W/D.TIME"]
+prototype = "W/D.TIME seconds"
+short = "set delay buffer length in `seconds` (s16V), when rate == 1"
+
+["W/D.LNG"]
+prototype = "W/D.LNG count divisions"
+short = "set buffer loop size as a fraction of buffer time (u8)"
+
+["W/D.POS"]
+prototype = "W/D.POS count divisions"
+short = "set loop location as a fraction of buffer time (u8)"
+
+["W/D.CUT"]
+prototype = "W/D.CUT count divisions"
+short = "jump to loop location as a fraction of buffer time (u8)"
+
+["W/D.FREQ.RNG"]
+prototype = "W/D.FREQ.RNG freq_range"
+short = "TBD (s8)"
+
+["W/D.RATE"]
+prototype = "W/D.RATE multiplier"
+short = "direct `multiplier` (s16V) of tape speed"
+
+["W/D.FREQ"]
+prototype = "W/D.FREQ volts"
+short = "manipulate tape speed with musical values (s16V)"
+
+["W/D.CLK"]
+prototype = "W/D.CLK"
+short = "receive clock pulse for synchronization"
+
+["W/D.CLK.RATIO"]
+prototype = "W/D.CLK.RATIO mul div"
+short = "set clock pulses per buffer time, with clock `mul`/`div` (s8)"
+
+["W/D.PLUCK"]
+prototype = "W/D.PLUCK volume"
+short = "pluck the delay line with noise at volume (s16V)"
+
+["W/D.MOD.RATE"]
+prototype = "W/D.MOD.RATE rate"
+short = "set the multiplier for the modulation rate (s16V)"
+
+["W/D.MOD.AMT"]
+prototype = "W/D.MOD.AMT amount"
+short = "set the `amount` (s16V) of delay line modulation to be applied"

--- a/docs/ops/wslashsynth.md
+++ b/docs/ops/wslashsynth.md
@@ -1,0 +1,5 @@
+## W/2.0 synth
+Synth mode of W/ eurorack module.
+
+More extensively covered in the [W/ Documentation](https://www.whimsicalraps.com/pages/w-type).
+

--- a/docs/ops/wslashsynth.toml
+++ b/docs/ops/wslashsynth.toml
@@ -1,0 +1,55 @@
+["W/S.PITCH"]
+prototype = "W/S.PITCH voice pitch"
+short = "set `voice` (s8) to `pitch` (s16V) in volts-per-octave"
+
+["W/S.VEL"]
+prototype = "W/S.VEL voice velocity"
+short = "strike the vactrol of `voice` (s8) at `velocity` (s16V) in volts"
+
+["W/S.VOX"]
+prototype = "W/S.VOX voice pitch velocity"
+short = "set `voice` (s8) to `pitch` (s16V) and strike the vactrol at `velocity` (s16V)"
+
+["W/S.NOTE"]
+prototype = "W/S.NOTE pitch level"
+short = "dynamically assign a voice, set to `pitch` (s16V), strike with `velocity`(s16V)"
+
+["W/S.AR.MODE"]
+prototype = "W/S.AR.MODE is_ar"
+short = "in attack-release mode, all notes are `plucked` and no `release` is required'"
+
+["W/S.LPG.TIME"]
+prototype = "W/S.LPG.TIME time"
+short = "vactrol `time` (s16V) constant. -5=drones, 0=vtl5c3, 5=blits"
+
+["W/S.LPG.SYM"]
+prototype = "W/S.LPG.SYM symmetry"
+short = "vactrol attack-release ratio. -5=fastest attack, 5=long swells (s16V)"
+
+["W/S.CURVE"]
+prototype = "W/S.CURVE curve"
+short = "cross-fade waveforms: -5=square, 0=triangle, 5=sine (s16V)"
+
+["W/S.RAMP"]
+prototype = "W/S.RAMP ramp"
+short = "waveform symmetry: -5=rampwave, 0=triangle, 5=sawtooth (NB: affects FM tone)"
+
+["W/S.FM.INDEX"]
+prototype = "W/S.FM.INDEX index"
+short = "amount of FM modulation. -5=negative, 0=minimum, 5=maximum (s16V)"
+
+["W/S.FM.RATIO"]
+prototype = "W/S.FM.RATIO num den"
+short = "ratio of the FM modulator to carrier as a ratio. floating point values up to 20.0 supported (s16V)"
+
+["W/S.FM.ENV"]
+prototype = "W/S.ENV amount"
+short = "amount of vactrol envelope applied to fm index, -5 to +5 (s16V)"
+
+["W/S.PATCH"]  
+prototype = "W/S.PATCH jack param"
+short = "patch a hardware `jack` (s8) to a `param` (s8) destination"
+
+["W/S.VOICES"]
+prototype = "W/S.VOICES count"
+short = "set number of polyphonic voices to allocate. use 0 for unison mode (s8)"

--- a/docs/ops/wslashsynth.toml
+++ b/docs/ops/wslashsynth.toml
@@ -43,7 +43,7 @@ prototype = "W/S.FM.RATIO num den"
 short = "ratio of the FM modulator to carrier as a ratio. floating point values up to 20.0 supported (s16V)"
 
 ["W/S.FM.ENV"]
-prototype = "W/S.ENV amount"
+prototype = "W/S.FM.ENV amount"
 short = "amount of vactrol envelope applied to fm index, -5 to +5 (s16V)"
 
 ["W/S.PATCH"]  

--- a/docs/ops/wslashtape.md
+++ b/docs/ops/wslashtape.md
@@ -1,0 +1,5 @@
+## W/2.0 tape
+Tape mode of W/ eurorack module.
+
+More extensively covered in the [W/ Documentation](https://www.whimsicalraps.com/pages/w-type).
+

--- a/docs/ops/wslashtape.toml
+++ b/docs/ops/wslashtape.toml
@@ -1,0 +1,63 @@
+["W/T.REC"]
+prototype = "W/T.REC active"
+short = "Sets recording state to `active` (s8)"
+
+["W/T.PLAY"]
+prototype = "W/T.PLAY playback"
+short = "Set the playback state. -1 will flip playback direction (s8)"
+
+["W/T.REV"]
+prototype = "W/T.REV"
+short = "Reverse the direction of playback"
+
+["W/T.SPEED"]
+prototype = "W/T.SPEED speed deno"
+short = "Set speed as a rate, or ratio. Negative values are reverse (s16V)"
+
+["W/T.FREQ"]
+prototype = "W/T.FREQ freq"
+short = "Set speed as a `frequency` (s16V) style value. Maintains reverse state"
+
+["W/T.PRE.LVL"]
+prototype = "W/T.PRE.LVL level"
+short = "Strength of erase head when recording. 0 is overdub, 1 is overwrite. Opposite of feedback (s16V)"
+
+["W/T.MONITOR.LVL"]
+prototype = "W/T.MONITOR.LVL gain"
+short = "Level of input passed directly to output (s16V)"
+
+["W/T.REC.LVL"]
+prototype = "W/T.REC.LVL gain"
+short = "Level of input material recorded to tape (s16V)"
+
+["W/T.HEAD.ORDER"]
+prototype = "W/T.HEAD.ORDER is_echo"
+short = "Set to 1 to playback before erase. 0 (default) erases first (s8)"
+
+["W/T.LOOP.START"]
+prototype = "W/T.LOOP.START"
+short = "Set the current time as the beginning of a loop"
+
+["W/T.LOOP.END"]
+prototype = "W/T.LOOP.END"
+short = "Set the current time as the loop end, and jump to start"
+
+["W/T.LOOP.ACTIVE"]
+prototype = "W/T.LOOP.ACTIVE state"
+short = "Set the state of looping (s8)"
+
+["W/T.LOOP.SCALE"]
+prototype = "W/T.LOOP.SCALE scale"
+short = "Mul(Positive) or Div(Negative) loop brace by arg. Zero resets to original window (s8)"
+
+["W/T.LOOP.NEXT"]
+prototype = "W/T.LOOP.NEXT direction"
+short = "Move loop brace forward/backward by length of loop. Zero jumps to loop start (s8)"
+
+["W/T.TIME"]
+prototype = "W/T.TIME seconds sub"
+short = "Move playhead to an arbitrary location on tape (s16)"
+
+["W/T.SEEK"]
+prototype = "W/T.SEEK seconds sub"
+short = "Move playhead relative to current position (s16)"

--- a/src/ops/i2c.c
+++ b/src/ops/i2c.c
@@ -264,32 +264,32 @@ static void op_IIBB3_get(const void *NOTUSED(data), scene_state_t *ss,
     query_byte(ss, cs);
 }
 
-void i2c_get_0(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_0(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     uint8_t d[] = { cmd };
     tele_ii_tx(addr, d, 1);
 }
 
-void i2c_get_8(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_8(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     uint8_t d[] = { cmd, (uint8_t)(a & 0xff) };
     tele_ii_tx(addr, d, 2);
 }
 
-void i2c_get_8_8(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_8_8(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
     uint8_t d[] = { cmd, (uint8_t)(a & 0xff), (uint8_t)(b & 0xff) };
     tele_ii_tx(addr, d, 3);
 }
 
-void i2c_get_8_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_8_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
     uint8_t d[] = { cmd, (uint8_t)(a & 0xff), b >> 8, b & 0xff };
     tele_ii_tx(addr, d, 4);
 }
 
-void i2c_get_8_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_8_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
     int16_t c = cs_pop(cs);
@@ -299,23 +299,39 @@ void i2c_get_8_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     tele_ii_tx(addr, d, 6);
 }
 
-void i2c_get_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     uint8_t d[] = { cmd, a >> 8, a & 0xff };
     tele_ii_tx(addr, d, 3);
 }
 
-void i2c_get_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
     uint8_t d[] = { cmd, a >> 8, a & 0xff, b >> 8, b & 0xff };
     tele_ii_tx(addr, d, 5);
 }
 
-void i2c_get_32(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+void i2c_write_32(command_state_t *cs, uint8_t addr, uint8_t cmd) {
     int16_t a = cs_pop(cs);
     uint8_t d[] = { cmd, a >> 8, a & 0xff, 0,
                     0 };  // currently used only for w/s.t which uses to last
                           // bytes to pass subseconds precission
     tele_ii_tx(addr, d, 5);
+}
+
+void i2c_recv_8(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+    i2c_write_0(cs, addr, cmd + 0x80);
+    uint8_t buffer[1] = { 0 };
+    tele_ii_rx(addr, buffer, 1);
+    int16_t value = buffer[0];
+    cs_push(cs, value);
+}
+
+void i2c_recv_16(command_state_t *cs, uint8_t addr, uint8_t cmd) {
+    i2c_write_0(cs, addr, cmd + 0x80);
+    uint8_t buffer[2] = { 0 };
+    tele_ii_rx(addr, buffer, 2);
+    int16_t value = (buffer[0] << 8) + buffer[1];
+    cs_push(cs, value);
 }

--- a/src/ops/i2c.h
+++ b/src/ops/i2c.h
@@ -26,35 +26,44 @@ extern const tele_op_t op_IIBB1;
 extern const tele_op_t op_IIBB2;
 extern const tele_op_t op_IIBB3;
 
-extern void i2c_get_0(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_8(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_8_8(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_8_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_8_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
-extern void i2c_get_32(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_0(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_8(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_8_8(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_8_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_8_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_16_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_write_32(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_recv_16(command_state_t *cs, uint8_t addr, uint8_t cmd);
+extern void i2c_recv_8(command_state_t *cs, uint8_t addr, uint8_t cmd);
 
-#define I2C_GET(name, addr, cmd, fn)                                        \
+#define I2C_WRITE(name, addr, cmd, fn)                                      \
     static void name(const void *NOTUSED(data), scene_state_t *NOTUSED(ss), \
                      exec_state_t *NOTUSED(es), command_state_t *cs) {      \
         fn(cs, addr, cmd);                                                  \
     }
 
-#define I2C_GET_0(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_0)
+#define I2C_WRITE_0(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_write_0)
 
-#define I2C_GET_8(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_8)
+#define I2C_WRITE_8(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_write_8)
 
-#define I2C_GET_8_8(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_8_8)
+#define I2C_WRITE_8_8(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_write_8_8)
 
-#define I2C_GET_8_16(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_8_16)
+#define I2C_WRITE_8_16(name, addr, cmd) \
+    I2C_WRITE(name, addr, cmd, i2c_write_8_16)
 
-#define I2C_GET_8_16_16(name, addr, cmd) \
-    I2C_GET(name, addr, cmd, i2c_get_8_16_16)
+#define I2C_WRITE_8_16_16(name, addr, cmd) \
+    I2C_WRITE(name, addr, cmd, i2c_write_8_16_16)
 
-#define I2C_GET_16(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_16)
+#define I2C_WRITE_16(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_write_16)
 
-#define I2C_GET_16_16(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_16_16)
+#define I2C_WRITE_16_16(name, addr, cmd) \
+    I2C_WRITE(name, addr, cmd, i2c_write_16_16)
 
-#define I2C_GET_32(name, addr, cmd) I2C_GET(name, addr, cmd, i2c_get_32)
+#define I2C_WRITE_32(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_write_32)
+
+#define I2C_RECV_8(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_recv_8)
+
+#define I2C_RECV_16(name, addr, cmd) I2C_WRITE(name, addr, cmd, i2c_recv_16)
+
 #endif

--- a/src/ops/wslashdelay.c
+++ b/src/ops/wslashdelay.c
@@ -6,37 +6,46 @@
 #include "teletype_io.h"
 
 I2C_WRITE_16(op_WS_D_FEEDBACK_write, WS_D_ADDR, WS_D_FEEDBACK)
+I2C_RECV_16(op_WS_D_FEEDBACK_recv, WS_D_ADDR, WS_D_FEEDBACK)
 I2C_WRITE_16(op_WS_D_MIX_write, WS_D_ADDR, WS_D_MIX)
+I2C_RECV_16(op_WS_D_MIX_recv, WS_D_ADDR, WS_D_MIX)
 I2C_WRITE_16(op_WS_D_LOWPASS_write, WS_D_ADDR, WS_D_LOWPASS)
+I2C_RECV_16(op_WS_D_LOWPASS_recv, WS_D_ADDR, WS_D_LOWPASS)
 I2C_WRITE_8(op_WS_D_FREEZE_write, WS_D_ADDR, WS_D_FREEZE)
+I2C_RECV_8(op_WS_D_FREEZE_recv, WS_D_ADDR, WS_D_FREEZE)
 I2C_WRITE_16(op_WS_D_TIME_write, WS_D_ADDR, WS_D_TIME)
+I2C_RECV_16(op_WS_D_TIME_recv, WS_D_ADDR, WS_D_TIME)
 I2C_WRITE_8_8(op_WS_D_LENGTH_write, WS_D_ADDR, WS_D_LENGTH)
 I2C_WRITE_8_8(op_WS_D_POSITION_write, WS_D_ADDR, WS_D_POSITION)
 I2C_WRITE_8_8(op_WS_D_CUT_write, WS_D_ADDR, WS_D_CUT)
 I2C_WRITE_8(op_WS_D_FREQ_RANGE_write, WS_D_ADDR, WS_D_FREQ_RANGE)
 I2C_WRITE_16(op_WS_D_RATE_write, WS_D_ADDR, WS_D_RATE)
+I2C_RECV_16(op_WS_D_RATE_recv, WS_D_ADDR, WS_D_RATE)
 I2C_WRITE_16(op_WS_D_FREQ_write, WS_D_ADDR, WS_D_FREQ)
+I2C_RECV_16(op_WS_D_FREQ_recv, WS_D_ADDR, WS_D_FREQ)
 I2C_WRITE_0(op_WS_D_CLK_write, WS_D_ADDR, WS_D_CLK)
 I2C_WRITE_8_8(op_WS_D_CLK_RATIO_write, WS_D_ADDR, WS_D_CLK_RATIO)
 I2C_WRITE_16(op_WS_D_PLUCK_write, WS_D_ADDR, WS_D_PLUCK)
 I2C_WRITE_16(op_WS_D_MOD_RATE_write, WS_D_ADDR, WS_D_MOD_RATE)
+I2C_RECV_16(op_WS_D_MOD_RATE_recv, WS_D_ADDR, WS_D_MOD_RATE)
 I2C_WRITE_16(op_WS_D_MOD_AMOUNT_write, WS_D_ADDR, WS_D_MOD_AMOUNT)
+I2C_RECV_16(op_WS_D_MOD_AMOUNT_recv, WS_D_ADDR, WS_D_MOD_AMOUNT)
 
 // clang-format off
-const tele_op_t op_WS_D_FEEDBACK = MAKE_GET_OP(W/D.FBK, op_WS_D_FEEDBACK_write, 1, false);
-const tele_op_t op_WS_D_MIX  = MAKE_GET_OP(W/D.MIX, op_WS_D_MIX_write, 1, false);
-const tele_op_t op_WS_D_LOWPASS = MAKE_GET_OP(W/D.LPASS, op_WS_D_LOWPASS_write, 1, false);
-const tele_op_t op_WS_D_FREEZE  = MAKE_GET_OP(W/D.FREEZE, op_WS_D_FREEZE_write, 1, false);
-const tele_op_t op_WS_D_TIME   = MAKE_GET_OP(W/D.TIME, op_WS_D_TIME_write, 1, false);
+const tele_op_t op_WS_D_FEEDBACK = MAKE_GET_SET_OP(W/D.FBK, op_WS_D_FEEDBACK_recv, op_WS_D_FEEDBACK_write, 0, true);
+const tele_op_t op_WS_D_MIX  = MAKE_GET_SET_OP(W/D.MIX, op_WS_D_MIX_recv, op_WS_D_MIX_write, 0, true);
+const tele_op_t op_WS_D_LOWPASS = MAKE_GET_SET_OP(W/D.LPASS, op_WS_D_LOWPASS_recv, op_WS_D_LOWPASS_write, 0, true);
+const tele_op_t op_WS_D_FREEZE  = MAKE_GET_SET_OP(W/D.FREEZE, op_WS_D_FREEZE_recv, op_WS_D_FREEZE_write, 0, true);
+const tele_op_t op_WS_D_TIME   = MAKE_GET_SET_OP(W/D.TIME, op_WS_D_TIME_recv, op_WS_D_TIME_write, 0, true);
 const tele_op_t op_WS_D_LENGTH   = MAKE_GET_OP(W/D.LNG, op_WS_D_LENGTH_write, 2, false);
 const tele_op_t op_WS_D_POSITION   = MAKE_GET_OP(W/D.POS, op_WS_D_POSITION_write, 2, false);
 const tele_op_t op_WS_D_CUT   = MAKE_GET_OP(W/D.CUT, op_WS_D_CUT_write, 2, false);
 const tele_op_t op_WS_D_FREQ_RANGE  = MAKE_GET_OP(W/D.FREQ.RNG, op_WS_D_FREQ_RANGE_write, 1, false);
-const tele_op_t op_WS_D_RATE   = MAKE_GET_OP(W/D.RATE, op_WS_D_RATE_write, 1, false);
-const tele_op_t op_WS_D_FREQ   = MAKE_GET_OP(W/D.FREQ, op_WS_D_FREQ_write, 1, false);
+const tele_op_t op_WS_D_RATE   = MAKE_GET_SET_OP(W/D.RATE, op_WS_D_RATE_recv, op_WS_D_RATE_write, 0, true);
+const tele_op_t op_WS_D_FREQ   = MAKE_GET_SET_OP(W/D.FREQ, op_WS_D_FREQ_recv, op_WS_D_FREQ_write, 0, true);
 const tele_op_t op_WS_D_CLK = MAKE_GET_OP(W/D.CLK, op_WS_D_CLK_write, 0, false);
 const tele_op_t op_WS_D_CLK_RATIO  = MAKE_GET_OP(W/D.CLK.RATIO, op_WS_D_CLK_RATIO_write, 2, false);
 const tele_op_t op_WS_D_PLUCK  = MAKE_GET_OP(W/D.PLUCK, op_WS_D_PLUCK_write, 1, false);
-const tele_op_t op_WS_D_MOD_RATE  = MAKE_GET_OP(W/D.MOD.RATE, op_WS_D_MOD_RATE_write, 1, false);
-const tele_op_t op_WS_D_MOD_AMOUNT  = MAKE_GET_OP(W/D.MOD.AMT, op_WS_D_MOD_AMOUNT_write, 1, false);
+const tele_op_t op_WS_D_MOD_RATE  = MAKE_GET_SET_OP(W/D.MOD.RATE, op_WS_D_MOD_RATE_recv, op_WS_D_MOD_RATE_write, 0, true);
+const tele_op_t op_WS_D_MOD_AMOUNT  = MAKE_GET_SET_OP(W/D.MOD.AMT, op_WS_D_MOD_AMOUNT_recv, op_WS_D_MOD_AMOUNT_write, 0, true);
 // clang-format on

--- a/src/ops/wslashdelay.c
+++ b/src/ops/wslashdelay.c
@@ -5,38 +5,38 @@
 #include "ii.h"
 #include "teletype_io.h"
 
-I2C_GET_16(op_WS_D_FEEDBACK_get, WS_D_ADDR, WS_D_FEEDBACK)
-I2C_GET_16(op_WS_D_MIX_get, WS_D_ADDR, WS_D_MIX)
-I2C_GET_16(op_WS_D_LOWPASS_get, WS_D_ADDR, WS_D_LOWPASS)
-I2C_GET_8(op_WS_D_FREEZE_get, WS_D_ADDR, WS_D_FREEZE)
-I2C_GET_16(op_WS_D_TIME_get, WS_D_ADDR, WS_D_TIME)
-I2C_GET_8_8(op_WS_D_LENGTH_get, WS_D_ADDR, WS_D_LENGTH)
-I2C_GET_8_8(op_WS_D_POSITION_get, WS_D_ADDR, WS_D_POSITION)
-I2C_GET_8_8(op_WS_D_CUT_get, WS_D_ADDR, WS_D_CUT)
-I2C_GET_8(op_WS_D_FREQ_RANGE_get, WS_D_ADDR, WS_D_FREQ_RANGE)
-I2C_GET_16(op_WS_D_RATE_get, WS_D_ADDR, WS_D_RATE)
-I2C_GET_16(op_WS_D_FREQ_get, WS_D_ADDR, WS_D_FREQ)
-I2C_GET_0(op_WS_D_CLK_get, WS_D_ADDR, WS_D_CLK)
-I2C_GET_8_8(op_WS_D_CLK_RATIO_get, WS_D_ADDR, WS_D_CLK_RATIO)
-I2C_GET_16(op_WS_D_PLUCK_get, WS_D_ADDR, WS_D_PLUCK)
-I2C_GET_16(op_WS_D_MOD_RATE_get, WS_D_ADDR, WS_D_MOD_RATE)
-I2C_GET_16(op_WS_D_MOD_AMOUNT_get, WS_D_ADDR, WS_D_MOD_AMOUNT)
+I2C_WRITE_16(op_WS_D_FEEDBACK_write, WS_D_ADDR, WS_D_FEEDBACK)
+I2C_WRITE_16(op_WS_D_MIX_write, WS_D_ADDR, WS_D_MIX)
+I2C_WRITE_16(op_WS_D_LOWPASS_write, WS_D_ADDR, WS_D_LOWPASS)
+I2C_WRITE_8(op_WS_D_FREEZE_write, WS_D_ADDR, WS_D_FREEZE)
+I2C_WRITE_16(op_WS_D_TIME_write, WS_D_ADDR, WS_D_TIME)
+I2C_WRITE_8_8(op_WS_D_LENGTH_write, WS_D_ADDR, WS_D_LENGTH)
+I2C_WRITE_8_8(op_WS_D_POSITION_write, WS_D_ADDR, WS_D_POSITION)
+I2C_WRITE_8_8(op_WS_D_CUT_write, WS_D_ADDR, WS_D_CUT)
+I2C_WRITE_8(op_WS_D_FREQ_RANGE_write, WS_D_ADDR, WS_D_FREQ_RANGE)
+I2C_WRITE_16(op_WS_D_RATE_write, WS_D_ADDR, WS_D_RATE)
+I2C_WRITE_16(op_WS_D_FREQ_write, WS_D_ADDR, WS_D_FREQ)
+I2C_WRITE_0(op_WS_D_CLK_write, WS_D_ADDR, WS_D_CLK)
+I2C_WRITE_8_8(op_WS_D_CLK_RATIO_write, WS_D_ADDR, WS_D_CLK_RATIO)
+I2C_WRITE_16(op_WS_D_PLUCK_write, WS_D_ADDR, WS_D_PLUCK)
+I2C_WRITE_16(op_WS_D_MOD_RATE_write, WS_D_ADDR, WS_D_MOD_RATE)
+I2C_WRITE_16(op_WS_D_MOD_AMOUNT_write, WS_D_ADDR, WS_D_MOD_AMOUNT)
 
 // clang-format off
-const tele_op_t op_WS_D_FEEDBACK = MAKE_GET_OP(W/D.FBK, op_WS_D_FEEDBACK_get, 1, false);
-const tele_op_t op_WS_D_MIX  = MAKE_GET_OP(W/D.MIX, op_WS_D_MIX_get, 1, false);
-const tele_op_t op_WS_D_LOWPASS = MAKE_GET_OP(W/D.LPASS, op_WS_D_LOWPASS_get, 1, false);
-const tele_op_t op_WS_D_FREEZE  = MAKE_GET_OP(W/D.FREEZE, op_WS_D_FREEZE_get, 1, false);
-const tele_op_t op_WS_D_TIME   = MAKE_GET_OP(W/D.TIME, op_WS_D_TIME_get, 1, false);
-const tele_op_t op_WS_D_LENGTH   = MAKE_GET_OP(W/D.LNG, op_WS_D_LENGTH_get, 2, false);
-const tele_op_t op_WS_D_POSITION   = MAKE_GET_OP(W/D.POS, op_WS_D_POSITION_get, 2, false);
-const tele_op_t op_WS_D_CUT   = MAKE_GET_OP(W/D.CUT, op_WS_D_CUT_get, 2, false);
-const tele_op_t op_WS_D_FREQ_RANGE  = MAKE_GET_OP(W/D.FREQ.RNG, op_WS_D_FREQ_RANGE_get, 1, false);
-const tele_op_t op_WS_D_RATE   = MAKE_GET_OP(W/D.RATE, op_WS_D_RATE_get, 1, false);
-const tele_op_t op_WS_D_FREQ   = MAKE_GET_OP(W/D.FREQ, op_WS_D_FREQ_get, 1, false);
-const tele_op_t op_WS_D_CLK = MAKE_GET_OP(W/D.CLK, op_WS_D_CLK_get, 0, false);
-const tele_op_t op_WS_D_CLK_RATIO  = MAKE_GET_OP(W/D.CLK.RATIO, op_WS_D_CLK_RATIO_get, 2, false);
-const tele_op_t op_WS_D_PLUCK  = MAKE_GET_OP(W/D.PLUCK, op_WS_D_PLUCK_get, 1, false);
-const tele_op_t op_WS_D_MOD_RATE  = MAKE_GET_OP(W/D.MOD.RATE, op_WS_D_MOD_RATE_get, 1, false);
-const tele_op_t op_WS_D_MOD_AMOUNT  = MAKE_GET_OP(W/D.MOD.AMT, op_WS_D_MOD_AMOUNT_get, 1, false);
+const tele_op_t op_WS_D_FEEDBACK = MAKE_GET_OP(W/D.FBK, op_WS_D_FEEDBACK_write, 1, false);
+const tele_op_t op_WS_D_MIX  = MAKE_GET_OP(W/D.MIX, op_WS_D_MIX_write, 1, false);
+const tele_op_t op_WS_D_LOWPASS = MAKE_GET_OP(W/D.LPASS, op_WS_D_LOWPASS_write, 1, false);
+const tele_op_t op_WS_D_FREEZE  = MAKE_GET_OP(W/D.FREEZE, op_WS_D_FREEZE_write, 1, false);
+const tele_op_t op_WS_D_TIME   = MAKE_GET_OP(W/D.TIME, op_WS_D_TIME_write, 1, false);
+const tele_op_t op_WS_D_LENGTH   = MAKE_GET_OP(W/D.LNG, op_WS_D_LENGTH_write, 2, false);
+const tele_op_t op_WS_D_POSITION   = MAKE_GET_OP(W/D.POS, op_WS_D_POSITION_write, 2, false);
+const tele_op_t op_WS_D_CUT   = MAKE_GET_OP(W/D.CUT, op_WS_D_CUT_write, 2, false);
+const tele_op_t op_WS_D_FREQ_RANGE  = MAKE_GET_OP(W/D.FREQ.RNG, op_WS_D_FREQ_RANGE_write, 1, false);
+const tele_op_t op_WS_D_RATE   = MAKE_GET_OP(W/D.RATE, op_WS_D_RATE_write, 1, false);
+const tele_op_t op_WS_D_FREQ   = MAKE_GET_OP(W/D.FREQ, op_WS_D_FREQ_write, 1, false);
+const tele_op_t op_WS_D_CLK = MAKE_GET_OP(W/D.CLK, op_WS_D_CLK_write, 0, false);
+const tele_op_t op_WS_D_CLK_RATIO  = MAKE_GET_OP(W/D.CLK.RATIO, op_WS_D_CLK_RATIO_write, 2, false);
+const tele_op_t op_WS_D_PLUCK  = MAKE_GET_OP(W/D.PLUCK, op_WS_D_PLUCK_write, 1, false);
+const tele_op_t op_WS_D_MOD_RATE  = MAKE_GET_OP(W/D.MOD.RATE, op_WS_D_MOD_RATE_write, 1, false);
+const tele_op_t op_WS_D_MOD_AMOUNT  = MAKE_GET_OP(W/D.MOD.AMT, op_WS_D_MOD_AMOUNT_write, 1, false);
 // clang-format on

--- a/src/ops/wslashsynth.c
+++ b/src/ops/wslashsynth.c
@@ -5,47 +5,56 @@
 #include "ii.h"
 #include "teletype_io.h"
 
-I2C_GET_8_16(op_WS_S_VEL_get, WS_S_ADDR, WS_S_VEL)
-I2C_GET_8_16(op_WS_S_PITCH_get, WS_S_ADDR, WS_S_PITCH)
+I2C_WRITE_8_16(op_WS_S_VEL_write, WS_S_ADDR, WS_S_VEL)
+I2C_WRITE_8_16(op_WS_S_PITCH_write, WS_S_ADDR, WS_S_PITCH)
 
-I2C_GET_8_16_16(op_WS_S_VOX_get, WS_S_ADDR, WS_S_VOX)
-I2C_GET_16_16(op_WS_S_NOTE_get, WS_S_ADDR, WS_S_NOTE)
+I2C_WRITE_8_16_16(op_WS_S_VOX_write, WS_S_ADDR, WS_S_VOX)
+I2C_WRITE_16_16(op_WS_S_NOTE_write, WS_S_ADDR, WS_S_NOTE)
 
-I2C_GET_8(op_WS_S_AR_MODE_get, WS_S_ADDR, WS_S_AR_MODE)
+I2C_WRITE_8(op_WS_S_AR_MODE_write, WS_S_ADDR, WS_S_AR_MODE)
+I2C_RECV_8(op_WS_S_AR_MODE_recv, WS_S_ADDR, WS_S_AR_MODE)
 
-I2C_GET_16(op_WS_S_CURVE_get, WS_S_ADDR, WS_S_CURVE)
-I2C_GET_16(op_WS_S_RAMP_get, WS_S_ADDR, WS_S_RAMP)
+I2C_WRITE_16(op_WS_S_CURVE_write, WS_S_ADDR, WS_S_CURVE)
+I2C_RECV_16(op_WS_S_CURVE_recv, WS_S_ADDR, WS_S_CURVE)
+I2C_WRITE_16(op_WS_S_RAMP_write, WS_S_ADDR, WS_S_RAMP)
+I2C_RECV_16(op_WS_S_RAMP_recv, WS_S_ADDR, WS_S_RAMP)
 
-I2C_GET_16(op_WS_S_FM_INDEX_get, WS_S_ADDR, WS_S_FM_INDEX)
-I2C_GET_16(op_WS_S_FM_ENV_get, WS_S_ADDR, WS_S_FM_ENV)
-I2C_GET_16_16(op_WS_S_FM_RATIO_get, WS_S_ADDR, WS_S_FM_RATIO)
+I2C_WRITE_16(op_WS_S_FM_INDEX_write, WS_S_ADDR, WS_S_FM_INDEX)
+I2C_RECV_16(op_WS_S_FM_INDEX_recv, WS_S_ADDR, WS_S_FM_INDEX)
+I2C_WRITE_16(op_WS_S_FM_ENV_write, WS_S_ADDR, WS_S_FM_ENV)
+I2C_RECV_16(op_WS_S_FM_ENV_recv, WS_S_ADDR, WS_S_FM_ENV)
+I2C_WRITE_16_16(op_WS_S_FM_RATIO_write, WS_S_ADDR, WS_S_FM_RATIO)
+I2C_RECV_16(op_WS_S_FM_RATIO_recv, WS_S_ADDR, WS_S_FM_RATIO)
 
-I2C_GET_16(op_WS_S_LPG_TIME_get, WS_S_ADDR, WS_S_LPG_TIME)
-I2C_GET_16(op_WS_S_LPG_SYMMETRY_get, WS_S_ADDR, WS_S_LPG_SYMMETRY)
+I2C_WRITE_16(op_WS_S_LPG_TIME_write, WS_S_ADDR, WS_S_LPG_TIME)
+I2C_RECV_16(op_WS_S_LPG_TIME_recv, WS_S_ADDR, WS_S_LPG_TIME)
+I2C_WRITE_16(op_WS_S_LPG_SYMMETRY_write, WS_S_ADDR, WS_S_LPG_SYMMETRY)
+I2C_RECV_16(op_WS_S_LPG_SYMMETRY_recv, WS_S_ADDR, WS_S_LPG_SYMMETRY)
 
-I2C_GET_8_8(op_WS_S_PATCH_get, WS_S_ADDR, WS_S_PATCH)
-I2C_GET_8(op_WS_S_VOICES_get, WS_S_ADDR, WS_S_VOICES)
+I2C_WRITE_8_8(op_WS_S_PATCH_write, WS_S_ADDR, WS_S_PATCH)
+I2C_WRITE_8(op_WS_S_VOICES_write, WS_S_ADDR, WS_S_VOICES)
+I2C_RECV_8(op_WS_S_VOICES_recv, WS_S_ADDR, WS_S_VOICES)
 
 // clang-format off
-const tele_op_t op_WS_S_PITCH  = MAKE_GET_OP(W/S.PITCH, op_WS_S_PITCH_get, 2, false);
-const tele_op_t op_WS_S_VEL  = MAKE_GET_OP(W/S.VEL, op_WS_S_VEL_get, 2, false);
+const tele_op_t op_WS_S_PITCH  = MAKE_GET_OP(W/S.PITCH, op_WS_S_PITCH_write, 2, false);
+const tele_op_t op_WS_S_VEL  = MAKE_GET_OP(W/S.VEL, op_WS_S_VEL_write, 2, false);
 
-const tele_op_t op_WS_S_VOX  = MAKE_GET_OP(W/S.VOX, op_WS_S_VOX_get, 3, false);
-const tele_op_t op_WS_S_NOTE  = MAKE_GET_OP(W/S.NOTE, op_WS_S_NOTE_get, 2, false);
+const tele_op_t op_WS_S_VOX  = MAKE_GET_OP(W/S.VOX, op_WS_S_VOX_write, 3, false);
+const tele_op_t op_WS_S_NOTE  = MAKE_GET_OP(W/S.NOTE, op_WS_S_NOTE_write, 2, false);
 
-const tele_op_t op_WS_S_AR_MODE  = MAKE_GET_OP(W/S.AR.MODE , op_WS_S_AR_MODE_get, 1, false);
+const tele_op_t op_WS_S_AR_MODE  = MAKE_GET_SET_OP(W/S.AR.MODE , op_WS_S_AR_MODE_recv, op_WS_S_AR_MODE_write, 0, true);
 
-const tele_op_t op_WS_S_CURVE  = MAKE_GET_OP(W/S.CURVE , op_WS_S_CURVE_get, 1, false);
-const tele_op_t op_WS_S_RAMP  = MAKE_GET_OP(W/S.RAMP , op_WS_S_RAMP_get, 1, false);
+const tele_op_t op_WS_S_CURVE  = MAKE_GET_SET_OP(W/S.CURVE , op_WS_S_CURVE_recv, op_WS_S_CURVE_write, 0, true);
+const tele_op_t op_WS_S_RAMP  = MAKE_GET_SET_OP(W/S.RAMP , op_WS_S_RAMP_recv, op_WS_S_RAMP_write, 0, true);
 
-const tele_op_t op_WS_S_FM_INDEX  = MAKE_GET_OP(W/S.FM.INDEX , op_WS_S_FM_INDEX_get, 1, false);
-const tele_op_t op_WS_S_FM_ENV  = MAKE_GET_OP(W/S.FM.ENV , op_WS_S_FM_ENV_get, 1, false);
-const tele_op_t op_WS_S_FM_RATIO  = MAKE_GET_OP(W/S.FM.RATIO , op_WS_S_FM_RATIO_get, 2, false);
+const tele_op_t op_WS_S_FM_INDEX  = MAKE_GET_SET_OP(W/S.FM.INDEX , op_WS_S_FM_INDEX_recv, op_WS_S_FM_INDEX_write, 0, true);
+const tele_op_t op_WS_S_FM_ENV  = MAKE_GET_SET_OP(W/S.FM.ENV , op_WS_S_FM_ENV_recv, op_WS_S_FM_ENV_write, 0, true);
+const tele_op_t op_WS_S_FM_RATIO  = MAKE_GET_SET_OP(W/S.FM.RATIO , op_WS_S_FM_RATIO_recv, op_WS_S_FM_RATIO_write, 0, true);
 
-const tele_op_t op_WS_S_LPG_TIME  = MAKE_GET_OP(W/S.LPG.TIME , op_WS_S_LPG_TIME_get, 1, false);
-const tele_op_t op_WS_S_LPG_SYMMETRY  = MAKE_GET_OP(W/S.LPG.SYM , op_WS_S_LPG_SYMMETRY_get, 1, false);
+const tele_op_t op_WS_S_LPG_TIME  = MAKE_GET_SET_OP(W/S.LPG.TIME , op_WS_S_LPG_TIME_recv, op_WS_S_LPG_TIME_write, 0, true);
+const tele_op_t op_WS_S_LPG_SYMMETRY  = MAKE_GET_SET_OP(W/S.LPG.SYM , op_WS_S_LPG_SYMMETRY_recv, op_WS_S_LPG_SYMMETRY_write, 0, true);
 
-const tele_op_t op_WS_S_PATCH  = MAKE_GET_OP(W/S.PATCH , op_WS_S_PATCH_get, 2, false);
-const tele_op_t op_WS_S_VOICES  = MAKE_GET_OP(W/S.VOICES , op_WS_S_VOICES_get, 1, false);
+const tele_op_t op_WS_S_PATCH  = MAKE_GET_OP(W/S.PATCH , op_WS_S_PATCH_write, 2, false);
+const tele_op_t op_WS_S_VOICES  = MAKE_GET_SET_OP(W/S.VOICES , op_WS_S_VOICES_recv, op_WS_S_VOICES_write, 0, true);
 
 // clang-format on

--- a/src/ops/wslashsynth.c
+++ b/src/ops/wslashsynth.c
@@ -24,7 +24,6 @@ I2C_RECV_16(op_WS_S_FM_INDEX_recv, WS_S_ADDR, WS_S_FM_INDEX)
 I2C_WRITE_16(op_WS_S_FM_ENV_write, WS_S_ADDR, WS_S_FM_ENV)
 I2C_RECV_16(op_WS_S_FM_ENV_recv, WS_S_ADDR, WS_S_FM_ENV)
 I2C_WRITE_16_16(op_WS_S_FM_RATIO_write, WS_S_ADDR, WS_S_FM_RATIO)
-I2C_RECV_16(op_WS_S_FM_RATIO_recv, WS_S_ADDR, WS_S_FM_RATIO)
 
 I2C_WRITE_16(op_WS_S_LPG_TIME_write, WS_S_ADDR, WS_S_LPG_TIME)
 I2C_RECV_16(op_WS_S_LPG_TIME_recv, WS_S_ADDR, WS_S_LPG_TIME)
@@ -49,7 +48,7 @@ const tele_op_t op_WS_S_RAMP  = MAKE_GET_SET_OP(W/S.RAMP , op_WS_S_RAMP_recv, op
 
 const tele_op_t op_WS_S_FM_INDEX  = MAKE_GET_SET_OP(W/S.FM.INDEX , op_WS_S_FM_INDEX_recv, op_WS_S_FM_INDEX_write, 0, true);
 const tele_op_t op_WS_S_FM_ENV  = MAKE_GET_SET_OP(W/S.FM.ENV , op_WS_S_FM_ENV_recv, op_WS_S_FM_ENV_write, 0, true);
-const tele_op_t op_WS_S_FM_RATIO  = MAKE_GET_SET_OP(W/S.FM.RATIO , op_WS_S_FM_RATIO_recv, op_WS_S_FM_RATIO_write, 0, true);
+const tele_op_t op_WS_S_FM_RATIO  = MAKE_GET_OP(W/S.FM.RATIO , op_WS_S_FM_RATIO_write, 2, false);
 
 const tele_op_t op_WS_S_LPG_TIME  = MAKE_GET_SET_OP(W/S.LPG.TIME , op_WS_S_LPG_TIME_recv, op_WS_S_LPG_TIME_write, 0, true);
 const tele_op_t op_WS_S_LPG_SYMMETRY  = MAKE_GET_SET_OP(W/S.LPG.SYM , op_WS_S_LPG_SYMMETRY_recv, op_WS_S_LPG_SYMMETRY_write, 0, true);

--- a/src/ops/wslashtape.c
+++ b/src/ops/wslashtape.c
@@ -6,36 +6,44 @@
 #include "teletype_io.h"
 
 I2C_WRITE_8(op_WS_T_RECORD_write, WS_T_ADDR, WS_T_RECORD)
+I2C_RECV_8(op_WS_T_RECORD_recv, WS_T_ADDR, WS_T_RECORD)
 I2C_WRITE_8(op_WS_T_PLAY_write, WS_T_ADDR, WS_T_PLAY)
+I2C_RECV_8(op_WS_T_PLAY_recv, WS_T_ADDR, WS_T_PLAY)
 I2C_WRITE_0(op_WS_T_REV_write, WS_T_ADDR, WS_T_REV)
 I2C_WRITE_16_16(op_WS_T_SPEED_write, WS_T_ADDR, WS_T_SPEED)
 I2C_WRITE_16(op_WS_T_FREQ_write, WS_T_ADDR, WS_T_FREQ)
+I2C_RECV_16(op_WS_T_FREQ_recv, WS_T_ADDR, WS_T_FREQ)
 I2C_WRITE_16(op_WS_T_PRE_LEVEL_write, WS_T_ADDR, WS_T_PRE_LEVEL)
+I2C_RECV_16(op_WS_T_PRE_LEVEL_recv, WS_T_ADDR, WS_T_PRE_LEVEL)
 I2C_WRITE_16(op_WS_T_MONITOR_LEVEL_write, WS_T_ADDR, WS_T_MONITOR_LEVEL)
+I2C_RECV_16(op_WS_T_MONITOR_LEVEL_recv, WS_T_ADDR, WS_T_MONITOR_LEVEL)
 I2C_WRITE_16(op_WS_T_REC_LEVEL_write, WS_T_ADDR, WS_T_REC_LEVEL)
+I2C_RECV_16(op_WS_T_REC_LEVEL_recv, WS_T_ADDR, WS_T_REC_LEVEL)
 I2C_WRITE_8(op_WS_T_HEAD_ORDER_write, WS_T_ADDR, WS_T_HEAD_ORDER)
+I2C_RECV_8(op_WS_T_HEAD_ORDER_recv, WS_T_ADDR, WS_T_HEAD_ORDER)
 I2C_WRITE_0(op_WS_T_LOOP_START_write, WS_T_ADDR, WS_T_LOOP_START)
 I2C_WRITE_0(op_WS_T_LOOP_END_write, WS_T_ADDR, WS_T_LOOP_END)
 I2C_WRITE_8(op_WS_T_LOOP_ACTIVE_write, WS_T_ADDR, WS_T_LOOP_ACTIVE)
 I2C_WRITE_8(op_WS_T_LOOP_SCALE_write, WS_T_ADDR, WS_T_LOOP_SCALE)
+I2C_RECV_8(op_WS_T_LOOP_SCALE_recv, WS_T_ADDR, WS_T_LOOP_SCALE)
 I2C_WRITE_8(op_WS_T_LOOP_NEXT_write, WS_T_ADDR, WS_T_LOOP_NEXT)
 I2C_WRITE_16_16(op_WS_T_TIMESTAMP_write, WS_T_ADDR, WS_T_TIMESTAMP)
 I2C_WRITE_16_16(op_WS_T_SEEK_write, WS_T_ADDR, WS_T_SEEK)
 
 // clang-format off
-const tele_op_t op_WS_T_RECORD = MAKE_GET_OP(W/T.REC, op_WS_T_RECORD_write, 1, false);
-const tele_op_t op_WS_T_PLAY   = MAKE_GET_OP(W/T.PLAY, op_WS_T_PLAY_write, 1, false);
+const tele_op_t op_WS_T_RECORD = MAKE_GET_SET_OP(W/T.REC, op_WS_T_RECORD_recv, op_WS_T_RECORD_write, 0, true);
+const tele_op_t op_WS_T_PLAY   = MAKE_GET_SET_OP(W/T.PLAY, op_WS_T_PLAY_recv, op_WS_T_PLAY_write, 0, true);
 const tele_op_t op_WS_T_REV = MAKE_GET_OP(W/T.REV, op_WS_T_REV_write, 0, false);
 const tele_op_t op_WS_T_SPEED   = MAKE_GET_OP(W/T.SPEED, op_WS_T_SPEED_write, 2, false);
-const tele_op_t op_WS_T_FREQ   = MAKE_GET_OP(W/T.FREQ, op_WS_T_FREQ_write, 1, false);
-const tele_op_t op_WS_T_PRE_LEVEL  = MAKE_GET_OP(W/T.PRE.LVL, op_WS_T_PRE_LEVEL_write, 1, false);
-const tele_op_t op_WS_T_MONITOR_LEVEL  = MAKE_GET_OP(W/T.MONITOR.LVL, op_WS_T_MONITOR_LEVEL_write, 1, false);
-const tele_op_t op_WS_T_REC_LEVEL  = MAKE_GET_OP(W/T.REC.LVL, op_WS_T_REC_LEVEL_write, 1, false);
-const tele_op_t op_WS_T_HEAD_ORDER  = MAKE_GET_OP(W/T.HEAD.ORDER, op_WS_T_HEAD_ORDER_write, 1, false);
+const tele_op_t op_WS_T_FREQ   = MAKE_GET_SET_OP(W/T.FREQ, op_WS_T_FREQ_recv, op_WS_T_FREQ_write, 0, true);
+const tele_op_t op_WS_T_PRE_LEVEL  = MAKE_GET_SET_OP(W/T.PRE.LVL, op_WS_T_PRE_LEVEL_recv, op_WS_T_PRE_LEVEL_write, 0, true);
+const tele_op_t op_WS_T_MONITOR_LEVEL  = MAKE_GET_SET_OP(W/T.MONITOR.LVL, op_WS_T_MONITOR_LEVEL_recv, op_WS_T_MONITOR_LEVEL_write, 0, true);
+const tele_op_t op_WS_T_REC_LEVEL  = MAKE_GET_SET_OP(W/T.REC.LVL, op_WS_T_REC_LEVEL_recv, op_WS_T_REC_LEVEL_write, 0, true);
+const tele_op_t op_WS_T_HEAD_ORDER  = MAKE_GET_SET_OP(W/T.HEAD.ORDER, op_WS_T_HEAD_ORDER_recv, op_WS_T_HEAD_ORDER_write, 0, true);
 const tele_op_t op_WS_T_LOOP_START = MAKE_GET_OP(W/T.LOOP.START, op_WS_T_LOOP_START_write, 0, false);
 const tele_op_t op_WS_T_LOOP_END  = MAKE_GET_OP(W/T.LOOP.END, op_WS_T_LOOP_END_write, 0, false);
 const tele_op_t op_WS_T_LOOP_ACTIVE  = MAKE_GET_OP(W/T.LOOP.ACTIVE, op_WS_T_LOOP_ACTIVE_write, 1, false);
-const tele_op_t op_WS_T_LOOP_SCALE  = MAKE_GET_OP(W/T.LOOP.SCALE, op_WS_T_LOOP_SCALE_write, 1, false);
+const tele_op_t op_WS_T_LOOP_SCALE  = MAKE_GET_SET_OP(W/T.LOOP.SCALE, op_WS_T_LOOP_SCALE_recv, op_WS_T_LOOP_SCALE_write, 0, true);
 const tele_op_t op_WS_T_LOOP_NEXT  = MAKE_GET_OP(W/T.LOOP.NEXT, op_WS_T_LOOP_NEXT_write, 1, false);
 const tele_op_t op_WS_T_TIMESTAMP   = MAKE_GET_OP(W/T.TIME, op_WS_T_TIMESTAMP_write, 2, false);
 const tele_op_t op_WS_T_SEEK  = MAKE_GET_OP(W/T.SEEK, op_WS_T_SEEK_write, 2, false);

--- a/src/ops/wslashtape.c
+++ b/src/ops/wslashtape.c
@@ -5,38 +5,38 @@
 #include "ii.h"
 #include "teletype_io.h"
 
-I2C_GET_8(op_WS_T_RECORD_get, WS_T_ADDR, WS_T_RECORD)
-I2C_GET_8(op_WS_T_PLAY_get, WS_T_ADDR, WS_T_PLAY)
-I2C_GET_0(op_WS_T_REV_get, WS_T_ADDR, WS_T_REV)
-I2C_GET_16_16(op_WS_T_SPEED_get, WS_T_ADDR, WS_T_SPEED)
-I2C_GET_16(op_WS_T_FREQ_get, WS_T_ADDR, WS_T_FREQ)
-I2C_GET_16(op_WS_T_PRE_LEVEL_get, WS_T_ADDR, WS_T_PRE_LEVEL)
-I2C_GET_16(op_WS_T_MONITOR_LEVEL_get, WS_T_ADDR, WS_T_MONITOR_LEVEL)
-I2C_GET_16(op_WS_T_REC_LEVEL_get, WS_T_ADDR, WS_T_REC_LEVEL)
-I2C_GET_8(op_WS_T_HEAD_ORDER_get, WS_T_ADDR, WS_T_HEAD_ORDER)
-I2C_GET_0(op_WS_T_LOOP_START_get, WS_T_ADDR, WS_T_LOOP_START)
-I2C_GET_0(op_WS_T_LOOP_END_get, WS_T_ADDR, WS_T_LOOP_END)
-I2C_GET_8(op_WS_T_LOOP_ACTIVE_get, WS_T_ADDR, WS_T_LOOP_ACTIVE)
-I2C_GET_8(op_WS_T_LOOP_SCALE_get, WS_T_ADDR, WS_T_LOOP_SCALE)
-I2C_GET_8(op_WS_T_LOOP_NEXT_get, WS_T_ADDR, WS_T_LOOP_NEXT)
-I2C_GET_16_16(op_WS_T_TIMESTAMP_get, WS_T_ADDR, WS_T_TIMESTAMP)
-I2C_GET_16_16(op_WS_T_SEEK_get, WS_T_ADDR, WS_T_SEEK)
+I2C_WRITE_8(op_WS_T_RECORD_write, WS_T_ADDR, WS_T_RECORD)
+I2C_WRITE_8(op_WS_T_PLAY_write, WS_T_ADDR, WS_T_PLAY)
+I2C_WRITE_0(op_WS_T_REV_write, WS_T_ADDR, WS_T_REV)
+I2C_WRITE_16_16(op_WS_T_SPEED_write, WS_T_ADDR, WS_T_SPEED)
+I2C_WRITE_16(op_WS_T_FREQ_write, WS_T_ADDR, WS_T_FREQ)
+I2C_WRITE_16(op_WS_T_PRE_LEVEL_write, WS_T_ADDR, WS_T_PRE_LEVEL)
+I2C_WRITE_16(op_WS_T_MONITOR_LEVEL_write, WS_T_ADDR, WS_T_MONITOR_LEVEL)
+I2C_WRITE_16(op_WS_T_REC_LEVEL_write, WS_T_ADDR, WS_T_REC_LEVEL)
+I2C_WRITE_8(op_WS_T_HEAD_ORDER_write, WS_T_ADDR, WS_T_HEAD_ORDER)
+I2C_WRITE_0(op_WS_T_LOOP_START_write, WS_T_ADDR, WS_T_LOOP_START)
+I2C_WRITE_0(op_WS_T_LOOP_END_write, WS_T_ADDR, WS_T_LOOP_END)
+I2C_WRITE_8(op_WS_T_LOOP_ACTIVE_write, WS_T_ADDR, WS_T_LOOP_ACTIVE)
+I2C_WRITE_8(op_WS_T_LOOP_SCALE_write, WS_T_ADDR, WS_T_LOOP_SCALE)
+I2C_WRITE_8(op_WS_T_LOOP_NEXT_write, WS_T_ADDR, WS_T_LOOP_NEXT)
+I2C_WRITE_16_16(op_WS_T_TIMESTAMP_write, WS_T_ADDR, WS_T_TIMESTAMP)
+I2C_WRITE_16_16(op_WS_T_SEEK_write, WS_T_ADDR, WS_T_SEEK)
 
 // clang-format off
-const tele_op_t op_WS_T_RECORD = MAKE_GET_OP(W/T.REC, op_WS_T_RECORD_get, 1, false);
-const tele_op_t op_WS_T_PLAY   = MAKE_GET_OP(W/T.PLAY, op_WS_T_PLAY_get, 1, false);
-const tele_op_t op_WS_T_REV = MAKE_GET_OP(W/T.REV, op_WS_T_REV_get, 0, false);
-const tele_op_t op_WS_T_SPEED   = MAKE_GET_OP(W/T.SPEED, op_WS_T_SPEED_get, 2, false);
-const tele_op_t op_WS_T_FREQ   = MAKE_GET_OP(W/T.FREQ, op_WS_T_FREQ_get, 1, false);
-const tele_op_t op_WS_T_PRE_LEVEL  = MAKE_GET_OP(W/T.PRE.LVL, op_WS_T_PRE_LEVEL_get, 1, false);
-const tele_op_t op_WS_T_MONITOR_LEVEL  = MAKE_GET_OP(W/T.MONITOR.LVL, op_WS_T_MONITOR_LEVEL_get, 1, false);
-const tele_op_t op_WS_T_REC_LEVEL  = MAKE_GET_OP(W/T.REC.LVL, op_WS_T_REC_LEVEL_get, 1, false);
-const tele_op_t op_WS_T_HEAD_ORDER  = MAKE_GET_OP(W/T.HEAD.ORDER, op_WS_T_HEAD_ORDER_get, 1, false);
-const tele_op_t op_WS_T_LOOP_START = MAKE_GET_OP(W/T.LOOP.START, op_WS_T_LOOP_START_get, 0, false);
-const tele_op_t op_WS_T_LOOP_END  = MAKE_GET_OP(W/T.LOOP.END, op_WS_T_LOOP_END_get, 0, false);
-const tele_op_t op_WS_T_LOOP_ACTIVE  = MAKE_GET_OP(W/T.LOOP.ACTIVE, op_WS_T_LOOP_ACTIVE_get, 1, false);
-const tele_op_t op_WS_T_LOOP_SCALE  = MAKE_GET_OP(W/T.LOOP.SCALE, op_WS_T_LOOP_SCALE_get, 1, false);
-const tele_op_t op_WS_T_LOOP_NEXT  = MAKE_GET_OP(W/T.LOOP.NEXT, op_WS_T_LOOP_NEXT_get, 1, false);
-const tele_op_t op_WS_T_TIMESTAMP   = MAKE_GET_OP(W/T.TIME, op_WS_T_TIMESTAMP_get, 2, false);
-const tele_op_t op_WS_T_SEEK  = MAKE_GET_OP(W/T.SEEK, op_WS_T_SEEK_get, 2, false);
+const tele_op_t op_WS_T_RECORD = MAKE_GET_OP(W/T.REC, op_WS_T_RECORD_write, 1, false);
+const tele_op_t op_WS_T_PLAY   = MAKE_GET_OP(W/T.PLAY, op_WS_T_PLAY_write, 1, false);
+const tele_op_t op_WS_T_REV = MAKE_GET_OP(W/T.REV, op_WS_T_REV_write, 0, false);
+const tele_op_t op_WS_T_SPEED   = MAKE_GET_OP(W/T.SPEED, op_WS_T_SPEED_write, 2, false);
+const tele_op_t op_WS_T_FREQ   = MAKE_GET_OP(W/T.FREQ, op_WS_T_FREQ_write, 1, false);
+const tele_op_t op_WS_T_PRE_LEVEL  = MAKE_GET_OP(W/T.PRE.LVL, op_WS_T_PRE_LEVEL_write, 1, false);
+const tele_op_t op_WS_T_MONITOR_LEVEL  = MAKE_GET_OP(W/T.MONITOR.LVL, op_WS_T_MONITOR_LEVEL_write, 1, false);
+const tele_op_t op_WS_T_REC_LEVEL  = MAKE_GET_OP(W/T.REC.LVL, op_WS_T_REC_LEVEL_write, 1, false);
+const tele_op_t op_WS_T_HEAD_ORDER  = MAKE_GET_OP(W/T.HEAD.ORDER, op_WS_T_HEAD_ORDER_write, 1, false);
+const tele_op_t op_WS_T_LOOP_START = MAKE_GET_OP(W/T.LOOP.START, op_WS_T_LOOP_START_write, 0, false);
+const tele_op_t op_WS_T_LOOP_END  = MAKE_GET_OP(W/T.LOOP.END, op_WS_T_LOOP_END_write, 0, false);
+const tele_op_t op_WS_T_LOOP_ACTIVE  = MAKE_GET_OP(W/T.LOOP.ACTIVE, op_WS_T_LOOP_ACTIVE_write, 1, false);
+const tele_op_t op_WS_T_LOOP_SCALE  = MAKE_GET_OP(W/T.LOOP.SCALE, op_WS_T_LOOP_SCALE_write, 1, false);
+const tele_op_t op_WS_T_LOOP_NEXT  = MAKE_GET_OP(W/T.LOOP.NEXT, op_WS_T_LOOP_NEXT_write, 1, false);
+const tele_op_t op_WS_T_TIMESTAMP   = MAKE_GET_OP(W/T.TIME, op_WS_T_TIMESTAMP_write, 2, false);
+const tele_op_t op_WS_T_SEEK  = MAKE_GET_OP(W/T.SEEK, op_WS_T_SEEK_write, 2, false);
 // clang-format on

--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -73,7 +73,8 @@ OPS_SECTIONS = [
     ("matrixarchate", "Matrixarchate", True),
     ("telex_i",       "TELEXi",        False),
     ("telex_o",       "TELEXo",        False),
-    ("disting",       "Disting EX",    False)
+    ("disting",       "Disting EX",    False),
+    ("wslashsynth",   "W/2.0 synth",   False),
 ]
 
 

--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -73,8 +73,10 @@ OPS_SECTIONS = [
     ("matrixarchate", "Matrixarchate", True),
     ("telex_i",       "TELEXi",        False),
     ("telex_o",       "TELEXo",        False),
-    ("disting",       "Disting EX",    False),
+    ("disting",       "Disting EX",    True),
+    ("wslashdelay",   "W/2.0 delay",   False),
     ("wslashsynth",   "W/2.0 synth",   False),
+    ("wslashtape",    "W/2.0 tape",    False),
 ]
 
 

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -58,7 +58,8 @@ OPS_SECTIONS = [
     "fader",
     "wslash",
     "matrixarchate",
-    "disting"
+    "disting",
+    "wslashsynth",
 ]
 
 

--- a/utils/docs.py
+++ b/utils/docs.py
@@ -59,7 +59,9 @@ OPS_SECTIONS = [
     "wslash",
     "matrixarchate",
     "disting",
+    "wslashdelay",
     "wslashsynth",
+    "wslashtape",
 ]
 
 


### PR DESCRIPTION
#### What does this PR do?
This PR will finish the work related to W/2.0 integration, by adding documentation, possibility to retrieve values from W/2.0 and making sure that all values are send/received properly

#### Provide links to any related discussion on [lines](https://llllllll.co/).
https://llllllll.co/t/teletype-and-w-2-0-integration/34220

#### How should this be manually tested?
By executing commands through i2c and verifying that both:
- W/2.0 leds in tape/delay/synth settings change accordingly to value sent
- same value as sent through i2c is received when reading data from W/2.0

#### Any background context you want to provide?
Hi,
Sorry for long silence, I tried to fix some outstanding issues previous weekend and will try to put more work into it next weekend.
I have updated the documentation using descriptions from lua config files in crow repo for W/2.0 i2c.
I have also added possibility to retrieve values from W/2.0. The only problem is that this obviously won't work with i2c messages which receive two vals from W/2.0. There is also some messages that expect 2 args when executed from teletype but return 1 val W/2.0 (like FM_RATIO in synth mode https://github.com/monome/crow/blob/main/lua/ii/wsyn.lua#L100) and this obviously won't work with MAKE_GET_SET_OP as it expects for setter to have only one argument. 
If there is anything missing that I not mentioned here please let me know and again thank you for your patience.
#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [ ] updated `CHANGELOG.md`
* [x] updated the documentation
* [ ] run `make format` on each commit
