### PR TITLE
add ES.CV ii op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,7 @@
 - **NEW**: binary scale ops `N.B` and `N.BX`
 - **NEW**: reverse binary for numbers: `R...`
 - **NEW**: reverse binary OP: `BREV`
+- **NEW**: `ES.CV` read earthsea CV values
 
 ## v3.2.0
 

--- a/docs/ops/earthsea.toml
+++ b/docs/ops/earthsea.toml
@@ -61,3 +61,7 @@ short = "Magic shape (1= halfspeed, 2=doublespeed, 3=linearize)"
 description = """
 Apply one of the magic shapes, (1= halfspeed, 2=doublespeed, 3=linearize). Other shapes are not currently available via II ops.
 """
+
+["ES.CV"]
+prototype = "ES.CV x "
+short = "get the current CV value for channel `x`"

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -184,7 +184,7 @@
         "WRP"         => { MATCH_OP(E_OP_WRP); };
         "QT"          => { MATCH_OP(E_OP_QT); };
         "QT.S"        => { MATCH_OP(E_OP_QT_S); };
-        "QT.CS"       => { MATCH_OP(E_OP_QT_CS); };		
+        "QT.CS"       => { MATCH_OP(E_OP_QT_CS); };
         "QT.B"        => { MATCH_OP(E_OP_QT_B); };
         "AVG"         => { MATCH_OP(E_OP_AVG); };
         "EQ"          => { MATCH_OP(E_OP_EQ); };
@@ -328,6 +328,7 @@
         "ES.STOP"     => { MATCH_OP(E_OP_ES_STOP); };
         "ES.TRIPLE"   => { MATCH_OP(E_OP_ES_TRIPLE); };
         "ES.MAGIC"    => { MATCH_OP(E_OP_ES_MAGIC); };
+        "ES.CV"       => { MATCH_OP(E_OP_ES_CV); };
 
         # orca
         "OR.TRK"      => { MATCH_OP(E_OP_OR_TRK); };
@@ -833,11 +834,11 @@
         "DEL.R"       => { MATCH_MOD(E_MOD_DEL_R); };
         "DEL.G"       => { MATCH_MOD(E_MOD_DEL_G); };
         "DEL.B"       => { MATCH_MOD(E_MOD_DEL_B); };
-		
+
 		# justfriends
         "JF0"         => { MATCH_MOD(E_MOD_JF0); };
         "JF1"         => { MATCH_MOD(E_MOD_JF1); };
-        "JF2"         => { MATCH_MOD(E_MOD_JF2); };		
+        "JF2"         => { MATCH_MOD(E_MOD_JF2); };
 
         # matrixarchate
         "MA.SELECT"   => { MATCH_OP(E_OP_MA_SELECT); };

--- a/src/ops/earthsea.c
+++ b/src/ops/earthsea.c
@@ -1,6 +1,11 @@
 #include "earthsea.h"
 
+#include "helpers.h"
 #include "ii.h"
+#include "teletype_io.h"
+
+static void op_ES_CV_get(const void *data, scene_state_t *ss, exec_state_t *es,
+                         command_state_t *cs);
 
 const tele_op_t op_ES_PRESET = MAKE_SIMPLE_I2C_OP(ES.PRESET, ES_PRESET);
 const tele_op_t op_ES_MODE = MAKE_SIMPLE_I2C_OP(ES.MODE, ES_MODE);
@@ -11,3 +16,17 @@ const tele_op_t op_ES_TRANS = MAKE_SIMPLE_I2C_OP(ES.TRANS, ES_TRANS);
 const tele_op_t op_ES_STOP = MAKE_SIMPLE_I2C_OP(ES.STOP, ES_STOP);
 const tele_op_t op_ES_TRIPLE = MAKE_SIMPLE_I2C_OP(ES.TRIPLE, ES_TRIPLE);
 const tele_op_t op_ES_MAGIC = MAKE_SIMPLE_I2C_OP(ES.MAGIC, ES_MAGIC);
+const tele_op_t op_ES_CV = MAKE_GET_OP(ES.CV, op_ES_CV_get, 1, true);
+
+static void op_ES_CV_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
+                         exec_state_t *NOTUSED(es), command_state_t *cs) {
+    int16_t a = cs_pop(cs);
+    a--;
+    uint8_t d[] = { ES_CV | II_GET, a & 0x3 };
+    uint8_t addr = ES;
+    tele_ii_tx(addr, d, 2);
+    d[0] = 0;
+    d[1] = 0;
+    tele_ii_rx(addr, d, 2);
+    cs_push(cs, (d[0] << 8) + d[1]);
+}

--- a/src/ops/earthsea.h
+++ b/src/ops/earthsea.h
@@ -12,5 +12,6 @@ extern const tele_op_t op_ES_TRANS;
 extern const tele_op_t op_ES_STOP;
 extern const tele_op_t op_ES_TRIPLE;
 extern const tele_op_t op_ES_MAGIC;
+extern const tele_op_t op_ES_CV;
 
 #endif

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -123,7 +123,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
 
     // earthsea
     &op_ES_PRESET, &op_ES_MODE, &op_ES_CLOCK, &op_ES_RESET, &op_ES_PATTERN,
-    &op_ES_TRANS, &op_ES_STOP, &op_ES_TRIPLE, &op_ES_MAGIC,
+    &op_ES_TRANS, &op_ES_STOP, &op_ES_TRIPLE, &op_ES_MAGIC, &op_ES_CV,
 
     // orca
     &op_OR_TRK, &op_OR_CLK, &op_OR_DIV, &op_OR_PHASE, &op_OR_RST, &op_OR_WGT,
@@ -287,9 +287,9 @@ const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
 
     // disting ex
     &mod_EX1, &mod_EX2, &mod_EX3, &mod_EX4,
-	
+
     // just friends
-    &mod_JF0, &mod_JF1, &mod_JF2	
+    &mod_JF0, &mod_JF1, &mod_JF2
 };
 
 /////////////////////////////////////////////////////////////////

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -287,6 +287,7 @@ typedef enum {
     E_OP_ES_STOP,
     E_OP_ES_TRIPLE,
     E_OP_ES_MAGIC,
+    E_OP_ES_CV,
     E_OP_OR_TRK,
     E_OP_OR_CLK,
     E_OP_OR_DIV,


### PR DESCRIPTION
#### What does this PR do?

Adds an `ES.CV` op to read the current pitch for a given output channel from either Trilogy Earthsea or Ansible Earthsea.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

This came to my attention on discord, not sure if it's been discussed on lines before.

#### How should this be manually tested?

Connect ii to Ansible running the patch in https://github.com/monome/ansible/pull/94 and hosting a grid. Switch Ansible into Earthsea mode. Check that `ES.CV 1` - `ES.CV 4` read as expected as multiple Earthsea keys are held.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [X] updated `CHANGELOG.md`
* [X] updated the documentation
* [X] run `make format` on each commit
