### PR TITLE
docs: removed superfluous parentheses

### DIFF
--- a/docs/ops/maths.toml
+++ b/docs/ops/maths.toml
@@ -182,7 +182,7 @@ short = "toggle bit `y` in value `x`"
 
 [BREV]
 prototype = "BREV x"
-short = "reverse bit order in value `x` ()"
+short = "reverse bit order in value `x`"
 
 [ABS]
 prototype = "ABS x"


### PR DESCRIPTION
#### What does this PR do?
Super small beauty fix in documention.

#### I have,
* [ ] updated `CHANGELOG.md` N/A
* [x] updated the documentation
* [ ] run `make format` on each commit N/A
