### PR TITLE
update the Just Type documentation reference as it pointed to an out …

### DIFF
--- a/docs/ops/justfriends.md
+++ b/docs/ops/justfriends.md
@@ -1,4 +1,4 @@
 ## Just Friends
 
-More extensively covered in the [Just Friends Documentation](https://www.whimsicalraps.com/pages/just-type).
+More extensively covered in the [Just Friends Documentation](https://github.com/whimsicalraps/Just-Friends/blob/main/Just-Type.md).
 


### PR DESCRIPTION
#### What does this PR do?

Just updates the link for extended JF 'Just Type' documentation.