### PR TITLE
Customize NVRAM address to enable larger core flash program

### DIFF
--- a/module/config.mk
+++ b/module/config.mk
@@ -250,7 +250,8 @@ CFLAGS = -fshort-enums -fno-common
 CPPFLAGS = -D BOARD=USER_BOARD -D UHD_ENABLE
 
 # Extra flags to use when linking
-LDFLAGS = -Wl,-e,_trampoline
+# NVRAM size may need to change if additional data is to be stored in scenes.
+LDFLAGS = -Wl,-e,_trampoline,--defsym=__flash_nvram_size__=200K
 
 # Pre- and post-build commands
 PREBUILD_CMD =


### PR DESCRIPTION
#### What does this PR do?

Sets a custom symbol for the linker script, causing the NVRAM to be moved further into the flash address space. This was necessitated as the TT program has grown beyond the allotted 256KB flash reserved for it.

NVRAM is just a marker in the flash memory space which enables an additional interface for read/writing data. It does *not* require any special hardware support, and the location is arbitrary - the flash memory it controls is homogeneous.

TT uses the NVRAM address marker as the basis for all non-volatile data storage (Saved scenes, and calibration data). The 512KB of flash memory was previously split 256/256kB between program/data (the default). This PR changes the split to 312/200kB. The current usage of NVRAM is ~198kB, so if any substantial amount of data is added to the stored data, this variable may need to be updated.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-firmware-discussion/13961/102?u=galapagoose

#### How should this be manually tested?

Typical TT usage, and particularly, making sure saved Scenes & calibration data are working across power cycles.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

fixes #250 

#### I have,
* [ ] updated `CHANGELOG.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [ ] run `make format` on each commit
* [ ] run tests
