### PR TITLE
Improve line editor movement. Add "delete to end of word" command.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,8 @@
 - **NEW**: W/2.0 ops documentation
 - **NEW**: `><`, `<>`, `>=<` and `<=>` OPs, checks if value is within or outside of range
 - **IMP**: new powerful Q OPs
+- **IMP**: Improved line editing movement (forward/backward by word skips intervening space).
+- **NEW**: Delete to end of word command `alt-d` added.
 
 ## v3.2.0
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -34,15 +34,16 @@ In most cases, the clipboard is shared between _live_, _edit_ and the 2 _preset_
 |----------------------------------------|-----------------------------------------|
 | **`<left>`** / **`ctrl-b`**            | move cursor left                        |
 | **`<right>`** / **`ctrl-f`**           | move cursor right                       |
-| **`ctrl-<left>`**                      | move left by one word                   |
-| **`ctrl-<right>`**                     | move right by one word                  |
+| **`ctrl-<left>`** / **`alt-b`**        | move left by one word                   |
+| **`ctrl-<right>`** / **`alt-f`**       | move right by one word                  |
 | **`<home>`** / **`ctrl-a`**            | move to beginning of line               |
 | **`<end>`** / **`ctrl-e`**             | move to end of line                     |
 | **`<backspace>`** / **`ctrl-h`**       | backwards delete one character          |
 | **`<delete>`** / **`ctrl-d`**          | forwards delete one character           |
 | **`shift-<backspace>`** / **`ctrl-u`** | delete from cursor to beginning         |
-| **`shift-<delete>`** / **`ctrl-e`**    | delete from cursor to end               |
+| **`shift-<delete>`** / **`ctrl-k`**    | delete from cursor to end               |
 | **`alt-<backspace>`** / **`ctrl-w`**   | delete from cursor to beginning of word |
+| **`alt-d`**                            | delete from cursor to end of word       |
 | **`ctrl-x`** / **`alt-x`**             | cut to clipboard                        |
 | **`ctrl-c`** / **`alt-c`**             | copy to clipboard                       |
 | **`ctrl-v`** / **`alt-v`**             | paste to clipboard                      |


### PR DESCRIPTION
#### What does this PR do?
- Adds "delete to end of word" command for line editing. Bound to `alt-d`.
- Adds additional keybinds for move forwards/backwards by word (`alt-f` and `alt-b`).
- Updates "move forward/backwards by word" commands to skip all intervening space between the cursor and the word e.g. in the line "A_ _ _B"  with the cursor at B, moving backwards by word will place the cursor at A instead of moving one space back per key press.

#### Provide links to any related discussion on [lines](https://llllllll.co/).
[Discussion here](https://llllllll.co/t/teletype-3-2-feature-requests-and-discussions/32052/427?u=svin).

#### How should this be manually tested?
- Type text in live or edit mode. Use `alt-f`, `alt-b`, `alt-d` keybinds.

#### Any background context you want to provide?
- Chosen new keybinds match existing use of [emacs keybinds](https://www.gnu.org/software/emacs/manual/html_node/emacs/Moving-Point.html).

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
