### PR TITLE
Load scene while keeping current pattern state

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **IMP**: new powerful Q OPs
 - **IMP**: Improved line editing movement (forward/backward by word skips intervening space).
 - **NEW**: Delete to end of word command `alt-d` added.
+- **NEW**: new op: `SCENE.P`
 
 ## v3.2.0
 

--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -202,6 +202,15 @@ Load scene `x` (0-31) without loading grid button and fader states.
 **WARNING**: You will lose any unsaved changes to your scene.
 """
 
+["SCENE.P"]
+prototype = "SCENE.P x"
+short = "load scene `x` (0-31) without loading pattern state"
+description = """
+Load scene `x` (0-31) without loading pattern data.
+
+**WARNING**: You will lose any unsaved changes to your scene.
+"""
+
 [KILL]
 prototype = "KILL"
 short = "clears stack, clears delays, cancels pulses, cancels slews, disables metronome"

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -17,6 +17,7 @@
 - **IMP**: DELAY_SIZE increased to 64 from 16
 - **FIX**: scale degree arguments 1-indexed: `N.S`, `N.CS`
 - **NEW**: Just Friends 4.0 OPs and dual JF OPs
+- **NEW**: `SCENE.P` OP: load another scene but keep current pattern state
 
 ## v3.2.0
 

--- a/module/flash.c
+++ b/module/flash.c
@@ -117,12 +117,15 @@ void flash_write(uint8_t preset_no, scene_state_t *scene,
 
 void flash_read(uint8_t preset_no, scene_state_t *scene,
                 char (*text)[SCENE_TEXT_LINES][SCENE_TEXT_CHARS],
-                uint8_t init_grid, uint8_t init_i2c_op_address) {
+                uint8_t init_pattern, uint8_t init_grid,
+                uint8_t init_i2c_op_address) {
     memcpy(ss_scripts_ptr(scene), &f.scenes[preset_no].scripts,
            // Exclude size of TEMP script as above
            ss_scripts_size() - sizeof(scene_script_t));
-    memcpy(ss_patterns_ptr(scene), &f.scenes[preset_no].patterns,
-           ss_patterns_size());
+    if (init_pattern) {
+        memcpy(ss_patterns_ptr(scene), &f.scenes[preset_no].patterns,
+               ss_patterns_size());
+    }
     if (init_grid) {
         memcpy(&grid_data, &f.scenes[preset_no].grid_data, sizeof(grid_data_t));
         unpack_grid(scene);

--- a/module/flash.h
+++ b/module/flash.h
@@ -13,7 +13,8 @@ u8 is_flash_fresh(void);
 void flash_prepare(void);
 void flash_read(uint8_t preset_no, scene_state_t *scene,
                 char (*text)[SCENE_TEXT_LINES][SCENE_TEXT_CHARS],
-                uint8_t init_grid, uint8_t init_i2c_op_address);
+                uint8_t init_pattern, uint8_t init_grid,
+                uint8_t init_i2c_op_address);
 void flash_write(uint8_t preset_no, scene_state_t *scene,
                  char (*text)[SCENE_TEXT_LINES][SCENE_TEXT_CHARS]);
 uint8_t flash_last_saved_scene(void);

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -104,7 +104,7 @@ const char* help2[HELP2_LENGTH] = { "2/16 VARIABLES",
                                     "Q.AVG|AVERAGE OF ALL Q",
                                     "J, K|UNIQUE PER SCRIPT" };
 
-#define HELP3_LENGTH 60
+#define HELP3_LENGTH 61
 const char* help3[HELP3_LENGTH] = { "3/16 PARAMETERS",
                                     " ",
                                     "TR A-D|SET TR VALUE (0,1)",
@@ -147,6 +147,7 @@ const char* help3[HELP3_LENGTH] = { "3/16 PARAMETERS",
                                     "   1 RISING, 2 FALLING, 3 BOTH",
                                     "SCENE|GET/SET SCENE #",
                                     "SCENE.G|SET SCENE, EXCL GRID",
+                                    "SCENE.P|SET SCENE, EXCL PATTERN",
                                     "LAST N|GET SCRIPT LAST RUN",
                                     " ",
                                     "// 16n FADERBANK OPS",

--- a/module/main.c
+++ b/module/main.c
@@ -322,23 +322,23 @@ static void safely_run_script(u8 script) {
 
 void midiScriptTimer_callback(void* obj) {
     u8 executed[SCRIPT_COUNT] = { 0 };
-    
+
     if (scene_state.midi.on_count) {
         safely_run_script(scene_state.midi.on_script);
         executed[scene_state.midi.on_script] = 1;
     }
-    
+
     if (scene_state.midi.off_count &&
         !executed[scene_state.midi.off_script]) {
         safely_run_script(scene_state.midi.off_script);
         executed[scene_state.midi.off_script] = 1;
     }
-    
+
     if (scene_state.midi.cc_count &&
         !executed[scene_state.midi.cc_script]) {
         safely_run_script(scene_state.midi.cc_script);
     }
-    
+
     scene_state.midi.on_count = 0;
     scene_state.midi.off_count = 0;
     scene_state.midi.cc_count = 0;
@@ -653,7 +653,7 @@ static void midi_control_change(u8 ch, u8 num, u8 val) {
     scene_state.midi.last_cc = val;
 
     if (scene_state.midi.cc_script != -1) {
-            
+
         u8 found = 0;
         for (u8 i = 0; i < scene_state.midi.cc_count; i++) {
             if (scene_state.midi.cn[i] == num &&
@@ -663,7 +663,7 @@ static void midi_control_change(u8 ch, u8 num, u8 val) {
                 break;
             }
         }
-        
+
         if (!found && scene_state.midi.cc_count < MAX_MIDI_EVENTS) {
             scene_state.midi.cc_channel[scene_state.midi.cc_count] = ch;
             scene_state.midi.cn[scene_state.midi.cc_count] = num;
@@ -1063,9 +1063,9 @@ void tele_ii_rx(uint8_t addr, uint8_t* data, uint8_t l) {
     i2c_leader_rx(addr, data, l);
 }
 
-void tele_scene(uint8_t i, uint8_t init_grid) {
+void tele_scene(uint8_t i, uint8_t init_grid, uint8_t init_pattern) {
     preset_select = i;
-    flash_read(i, &scene_state, &scene_text, init_grid, 0);
+    flash_read(i, &scene_state, &scene_text, init_pattern, init_grid, 0);
     if (init_grid) scene_state.grid.scr_dirty = scene_state.grid.grid_dirty = 1;
 }
 
@@ -1172,7 +1172,7 @@ int main(void) {
     // load preset from flash
     preset_select = flash_last_saved_scene();
     ss_set_scene(&scene_state, preset_select);
-    flash_read(preset_select, &scene_state, &scene_text, 1, 1);
+    flash_read(preset_select, &scene_state, &scene_text, 1, 1, 1);
 
     // setup daisy chain for two dacs
     spi_selectChip(DAC_SPI, DAC_SPI_NPCS);
@@ -1215,7 +1215,7 @@ int main(void) {
     uint32_t count = 0;
 #endif
     while (true) {
-        midi_read(); 
+        midi_read();
         check_events();
 #ifdef TELETYPE_PROFILE
         count = (count + 1) % (FCPU_HZ / 10);

--- a/module/preset_r_mode.c
+++ b/module/preset_r_mode.c
@@ -107,7 +107,7 @@ uint8_t screen_refresh_preset_r() {
 
 void do_preset_read() {
     ss_grid_init(&scene_state);
-    flash_read(preset_select, &scene_state, &scene_text, 1, 1);
+    flash_read(preset_select, &scene_state, &scene_text, 1, 1, 1);
     flash_update_last_saved_scene(preset_select);
     ss_set_scene(&scene_state, preset_select);
 

--- a/module/usb_disk_mode.c
+++ b/module/usb_disk_mode.c
@@ -82,7 +82,7 @@ void tele_usb_disk() {
             font_string_region_clip_tab(&line[0], input_buffer, 2, 0, 0xa, 0);
             region_draw(&line[0]);
 
-            flash_read(i, &scene, &text, 1, 1);
+            flash_read(i, &scene, &text, 1, 1, 1);
 
             if (!nav_file_create((FS_STRING)filename)) {
                 if (fs_g_status != FS_ERR_FILE_EXIST) {

--- a/simulator/tt.c
+++ b/simulator/tt.c
@@ -79,7 +79,7 @@ void tele_ii_rx(uint8_t addr, uint8_t *data, uint8_t l) {
     printf("\n");
 }
 
-void tele_scene(uint8_t i, uint8_t init_grid) {
+void tele_scene(uint8_t i, uint8_t init_grid, uint8_t init_pattern) {
     printf("SCENE  i:%" PRIu8, i);
     printf("\n");
 }

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -203,7 +203,7 @@
         "QT.S"        => { MATCH_OP(E_OP_QT_S); };
         "QT.CS"       => { MATCH_OP(E_OP_QT_CS); };
         "QT.B"        => { MATCH_OP(E_OP_QT_B); };
-        "QT.BX"       => { MATCH_OP(E_OP_QT_BX); };		
+        "QT.BX"       => { MATCH_OP(E_OP_QT_BX); };
         "AVG"         => { MATCH_OP(E_OP_AVG); };
         "EQ"          => { MATCH_OP(E_OP_EQ); };
         "NE"          => { MATCH_OP(E_OP_NE); };
@@ -293,6 +293,7 @@
         "KILL"        => { MATCH_OP(E_OP_KILL); };
         "SCENE"       => { MATCH_OP(E_OP_SCENE); };
         "SCENE.G"     => { MATCH_OP(E_OP_SCENE_G); };
+        "SCENE.P"     => { MATCH_OP(E_OP_SCENE_P); };
         "BREAK"       => { MATCH_OP(E_OP_BREAK); };
         "BRK"         => { MATCH_OP(E_OP_BRK); };
         "SYNC"        => { MATCH_OP(E_OP_SYNC); };

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -37,6 +37,8 @@ static void op_SCENE_set(const void *data, scene_state_t *ss, exec_state_t *es,
                          command_state_t *cs);
 static void op_SCENE_G_get(const void *data, scene_state_t *ss,
                            exec_state_t *es, command_state_t *cs);
+static void op_SCENE_P_get(const void *data, scene_state_t *ss,
+                          exec_state_t *es, command_state_t *cs);
 static void op_SCRIPT_get(const void *data, scene_state_t *ss, exec_state_t *es,
                           command_state_t *cs);
 static void op_SCRIPT_set(const void *data, scene_state_t *ss, exec_state_t *es,
@@ -70,6 +72,7 @@ const tele_op_t op_SCRIPT_POL = MAKE_GET_SET_OP(SCRIPT.POL, op_SCRIPT_POL_get, o
 const tele_op_t op_SYM_DOLLAR_POL = MAKE_ALIAS_OP($.POL, op_SCRIPT_POL_get, op_SCRIPT_POL_set, 1, true);
 const tele_op_t op_KILL = MAKE_GET_OP(KILL, op_KILL_get, 0, false);
 const tele_op_t op_SCENE_G = MAKE_GET_OP(SCENE.G, op_SCENE_G_get, 1, false);
+const tele_op_t op_SCENE_P = MAKE_GET_OP(SCENE.P, op_SCENE_P_get, 1, false);
 const tele_op_t op_SCENE = MAKE_GET_SET_OP(SCENE, op_SCENE_get, op_SCENE_set, 0, true);
 const tele_op_t op_BREAK = MAKE_GET_OP(BREAK, op_BREAK_get, 0, false);
 const tele_op_t op_BRK = MAKE_ALIAS_OP(BRK, op_BREAK_get, NULL, 0, false);
@@ -219,7 +222,7 @@ static void op_SCENE_set(const void *NOTUSED(data), scene_state_t *ss,
     int16_t scene = cs_pop(cs);
     if (!ss->initializing) {
         ss->variables.scene = scene;
-        tele_scene(scene, 1);
+        tele_scene(scene, 1, 1);
     }
 }
 
@@ -228,7 +231,16 @@ static void op_SCENE_G_get(const void *NOTUSED(data), scene_state_t *ss,
     int16_t scene = cs_pop(cs);
     if (!ss->initializing) {
         ss->variables.scene = scene;
-        tele_scene(scene, 0);
+        tele_scene(scene, 0, 1);
+    }
+}
+
+static void op_SCENE_P_get(const void *NOTUSED(data), scene_state_t *ss,
+                           exec_state_t *NOTUSED(es), command_state_t *cs) {
+    int16_t scene = cs_pop(cs);
+    if (!ss->initializing) {
+        ss->variables.scene = scene;
+        tele_scene(scene, 1, 0);
     }
 }
 

--- a/src/ops/controlflow.h
+++ b/src/ops/controlflow.h
@@ -20,6 +20,7 @@ extern const tele_op_t op_SYM_DOLLAR_POL;
 extern const tele_op_t op_KILL;
 extern const tele_op_t op_SCENE;
 extern const tele_op_t op_SCENE_G;
+extern const tele_op_t op_SCENE_P;
 extern const tele_op_t op_BREAK;
 extern const tele_op_t op_BRK;
 extern const tele_op_t op_SYNC;

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -112,7 +112,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
 
     // controlflow
     &op_SCRIPT, &op_SYM_DOLLAR, &op_SCRIPT_POL, &op_SYM_DOLLAR_POL, &op_KILL,
-    &op_SCENE, &op_SCENE_G, &op_BREAK, &op_BRK, &op_SYNC,
+    &op_SCENE, &op_SCENE_G, &op_SCENE_P, &op_BREAK, &op_BRK, &op_SYNC,
 
     // delay
     &op_DEL_CLR,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -262,6 +262,7 @@ typedef enum {
     E_OP_KILL,
     E_OP_SCENE,
     E_OP_SCENE_G,
+    E_OP_SCENE_P,
     E_OP_BREAK,
     E_OP_BRK,
     E_OP_SYNC,

--- a/src/teletype_io.h
+++ b/src/teletype_io.h
@@ -31,7 +31,7 @@ extern void tele_has_stack(bool has_stack);
 extern void tele_cv_off(uint8_t i, int16_t v);
 extern void tele_ii_tx(uint8_t addr, uint8_t *data, uint8_t l);
 extern void tele_ii_rx(uint8_t addr, uint8_t *data, uint8_t l);
-extern void tele_scene(uint8_t i, uint8_t init_grid);
+extern void tele_scene(uint8_t i, uint8_t init_grid, uint8_t init_pattern);
 
 // called when a pattern is updated
 extern void tele_pattern_updated(void);

--- a/tests/main.c
+++ b/tests/main.c
@@ -25,7 +25,7 @@ void tele_has_stack(bool i) {}
 void tele_cv_off(uint8_t i, int16_t v) {}
 void tele_ii_tx(uint8_t addr, uint8_t *data, uint8_t l) {}
 void tele_ii_rx(uint8_t addr, uint8_t *data, uint8_t l) {}
-void tele_scene(uint8_t i, uint8_t init_grid) {}
+void tele_scene(uint8_t i, uint8_t init_grid, uint8_t init_pattern) {}
 void tele_pattern_updated() {}
 void tele_kill() {}
 void tele_mute() {}


### PR DESCRIPTION
#### What does this PR do?

This op loads a scene without loading the scenes pattern data, similar to `SCENE.G` for grid configuration.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

#### How should this be manually tested?

Create two scenes with different pattern data. Load the first scene. Use `SCENE.P` to load the second scene. Confirm that the pattern data has stayed the same, instead of loading pattern data from the second scene.

#### Any background context you want to provide?

The idea behind this feature is to be able to jam with the same set of pattern data across multiple scenes.

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] updated `help_mode.c` (if applicable)
* [ ] run `make format` on each commit
* [x] run tests
