### PR TITLE
Add `EV` alias for `EVERY` op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **NEW**: Delete to end of word command `alt-d` added.
 - **NEW**: new op: `SCENE.P`
 - **NEW**: new multi-logic OPs `AND3`, `AND4`, `OR3` and `OR4` with aliases `&&&`, `&&&&`, `|||` and `||||`
+- **NEW**: alias: `EY` for `EVERY`
 
 ## v3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,7 +31,7 @@
 - **NEW**: Delete to end of word command `alt-d` added.
 - **NEW**: new op: `SCENE.P`
 - **NEW**: new multi-logic OPs `AND3`, `AND4`, `OR3` and `OR4` with aliases `&&&`, `&&&&`, `|||` and `||||`
-- **NEW**: alias: `EY` for `EVERY`
+- **NEW**: alias: `EV` for `EVERY`
 
 ## v3.2.0
 

--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -94,7 +94,7 @@ A will be 256.
 
 [EVERY]
 prototype = "EVERY x: ..."
-aliases = ["EY"]
+aliases = ["EV"]
 short = "run the command every `x` times the command is called"
 description = """
 Runs the command every `x` times the line is executed.  This is tracked on a per-line basis, so each script can have 6 different "dividers".

--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -94,6 +94,7 @@ A will be 256.
 
 [EVERY]
 prototype = "EVERY x: ..."
+aliases = ["EY"]
 short = "run the command every `x` times the command is called"
 description = """
 Runs the command every `x` times the line is executed.  This is tracked on a per-line basis, so each script can have 6 different "dividers".

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -18,6 +18,7 @@
 - **FIX**: scale degree arguments 1-indexed: `N.S`, `N.CS`
 - **NEW**: Just Friends 4.0 OPs and dual JF OPs
 - **NEW**: `SCENE.P` OP: load another scene but keep current pattern state
+- **NEW**: alias: `EY` for `EVERY`
 
 ## v3.2.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -18,7 +18,7 @@
 - **FIX**: scale degree arguments 1-indexed: `N.S`, `N.CS`
 - **NEW**: Just Friends 4.0 OPs and dual JF OPs
 - **NEW**: `SCENE.P` OP: load another scene but keep current pattern state
-- **NEW**: alias: `EY` for `EVERY`
+- **NEW**: alias: `EV` for `EVERY`
 
 ## v3.2.0
 

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -876,7 +876,7 @@
         "L"           => { MATCH_MOD(E_MOD_L); };
         "W"           => { MATCH_MOD(E_MOD_W); };
         "EVERY"       => { MATCH_MOD(E_MOD_EVERY); };
-        "EY"          => { MATCH_MOD(E_MOD_EY); };
+        "EV"          => { MATCH_MOD(E_MOD_EV); };
         "SKIP"        => { MATCH_MOD(E_MOD_SKIP); };
         "OTHER"       => { MATCH_MOD(E_MOD_OTHER); };
         "EX1"         => { MATCH_MOD(E_MOD_EX1); };

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -876,6 +876,7 @@
         "L"           => { MATCH_MOD(E_MOD_L); };
         "W"           => { MATCH_MOD(E_MOD_W); };
         "EVERY"       => { MATCH_MOD(E_MOD_EVERY); };
+        "EY"          => { MATCH_MOD(E_MOD_EY); };
         "SKIP"        => { MATCH_MOD(E_MOD_SKIP); };
         "OTHER"       => { MATCH_MOD(E_MOD_OTHER); };
         "EX1"         => { MATCH_MOD(E_MOD_EX1); };

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -63,6 +63,7 @@ const tele_mod_t mod_ELSE = MAKE_MOD(ELSE, mod_ELSE_func, 0);
 const tele_mod_t mod_L = MAKE_MOD(L, mod_L_func, 2);
 const tele_mod_t mod_W = MAKE_MOD(W, mod_W_func, 1);
 const tele_mod_t mod_EVERY = MAKE_MOD(EVERY, mod_EVERY_func, 1);
+const tele_mod_t mod_EY = MAKE_MOD(EY, mod_EVERY_func, 1);
 const tele_mod_t mod_SKIP = MAKE_MOD(SKIP, mod_SKIP_func, 1);
 const tele_mod_t mod_OTHER = MAKE_MOD(OTHER, mod_OTHER_func, 0);
 

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -63,7 +63,7 @@ const tele_mod_t mod_ELSE = MAKE_MOD(ELSE, mod_ELSE_func, 0);
 const tele_mod_t mod_L = MAKE_MOD(L, mod_L_func, 2);
 const tele_mod_t mod_W = MAKE_MOD(W, mod_W_func, 1);
 const tele_mod_t mod_EVERY = MAKE_MOD(EVERY, mod_EVERY_func, 1);
-const tele_mod_t mod_EY = MAKE_MOD(EY, mod_EVERY_func, 1);
+const tele_mod_t mod_EV = MAKE_MOD(EV, mod_EVERY_func, 1);
 const tele_mod_t mod_SKIP = MAKE_MOD(SKIP, mod_SKIP_func, 1);
 const tele_mod_t mod_OTHER = MAKE_MOD(OTHER, mod_OTHER_func, 0);
 

--- a/src/ops/controlflow.h
+++ b/src/ops/controlflow.h
@@ -10,6 +10,7 @@ extern const tele_mod_t mod_ELSE;
 extern const tele_mod_t mod_L;
 extern const tele_mod_t mod_W;
 extern const tele_mod_t mod_EVERY;
+extern const tele_mod_t mod_EY;
 extern const tele_mod_t mod_SKIP;
 extern const tele_mod_t mod_OTHER;
 

--- a/src/ops/controlflow.h
+++ b/src/ops/controlflow.h
@@ -10,7 +10,7 @@ extern const tele_mod_t mod_ELSE;
 extern const tele_mod_t mod_L;
 extern const tele_mod_t mod_W;
 extern const tele_mod_t mod_EVERY;
-extern const tele_mod_t mod_EY;
+extern const tele_mod_t mod_EV;
 extern const tele_mod_t mod_SKIP;
 extern const tele_mod_t mod_OTHER;
 

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -290,7 +290,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
 
 const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     // controlflow
-    &mod_IF, &mod_ELIF, &mod_ELSE, &mod_L, &mod_W, &mod_EVERY, &mod_EY,
+    &mod_IF, &mod_ELIF, &mod_ELSE, &mod_L, &mod_W, &mod_EVERY, &mod_EV,
     &mod_SKIP, &mod_OTHER, &mod_PROB,
 
     // delay

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -290,8 +290,8 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
 
 const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     // controlflow
-    &mod_IF, &mod_ELIF, &mod_ELSE, &mod_L, &mod_W, &mod_EVERY, &mod_SKIP,
-    &mod_OTHER, &mod_PROB,
+    &mod_IF, &mod_ELIF, &mod_ELSE, &mod_L, &mod_W, &mod_EVERY, &mod_EY,
+    &mod_SKIP, &mod_OTHER, &mod_PROB,
 
     // delay
     &mod_DEL, &mod_DEL_X, &mod_DEL_R, &mod_DEL_G, &mod_DEL_B,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -802,7 +802,7 @@ typedef enum {
     E_MOD_L,
     E_MOD_W,
     E_MOD_EVERY,
-    E_MOD_EY,
+    E_MOD_EV,
     E_MOD_SKIP,
     E_MOD_OTHER,
     E_MOD_PROB,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -802,6 +802,7 @@ typedef enum {
     E_MOD_L,
     E_MOD_W,
     E_MOD_EVERY,
+    E_MOD_EY,
     E_MOD_SKIP,
     E_MOD_OTHER,
     E_MOD_PROB,


### PR DESCRIPTION
#### What does this PR do?

Adds an `EV` alias for the `EVERY` op to save character space.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

Comment on Lines: https://llllllll.co/t/teletype-3-2-feature-requests-and-discussions/32052/443

#### How should this be manually tested?

Use `EV` instead of `EVERY` in a script.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md`
* [x] updated the documentation
* [x] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
