### PR TITLE
various fixes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -35,6 +35,11 @@
 - **NEW**: live mode dashboard
 - **NEW**: ops to control live mode: `LIVE.OFF`, `LIVE.VARS`, `LIVE.GRID`, `LIVE.DASH`, `PRINT`
 - **FIX**: `PN.ROT` parameters are swapped
+- **FIX**: better rendering for fine grid faders
+- **FIX**: logical operators should treat all non zero values as `true`, not just positive values
+- **NEW**: crow ops
+- **NEW**: `TI.PRM.CALIB` alias added (was already in the docs)
+- **FIX**: `SCENE` would crash if parameter was out of bounds
 
 ## v3.2.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -36,6 +36,11 @@
 - **NEW**: live mode dashboard
 - **NEW**: ops to control live mode: `LIVE.OFF`, `LIVE.VARS`, `LIVE.GRID`, `LIVE.DASH`, `PRINT`
 - **FIX**: `PN.ROT` parameters are swapped
+- **FIX**: better rendering for fine grid faders
+- **FIX**: logical operators should treat all non zero values as `true`, not just positive values
+- **NEW**: crow ops
+- **NEW**: `TI.PRM.CALIB` alias added (was already in the docs)
+- **FIX**: `SCENE` would crash if parameter was out of bounds
 
 ## v3.2.0
 

--- a/module/flash.c
+++ b/module/flash.c
@@ -119,6 +119,7 @@ void flash_read(uint8_t preset_no, scene_state_t *scene,
                 char (*text)[SCENE_TEXT_LINES][SCENE_TEXT_CHARS],
                 uint8_t init_pattern, uint8_t init_grid,
                 uint8_t init_i2c_op_address) {
+    if (preset_no >= SCENE_SLOTS) return;
     memcpy(ss_scripts_ptr(scene), &f.scenes[preset_no].scripts,
            // Exclude size of TEMP script as above
            ss_scripts_size() - sizeof(scene_script_t));

--- a/module/main.c
+++ b/module/main.c
@@ -1065,6 +1065,7 @@ void tele_ii_rx(uint8_t addr, uint8_t* data, uint8_t l) {
 }
 
 void tele_scene(uint8_t i, uint8_t init_grid, uint8_t init_pattern) {
+    if (i >= SCENE_SLOTS) return;
     preset_select = i;
     flash_read(i, &scene_state, &scene_text, init_pattern, init_grid, 0);
     set_dash_updated();

--- a/simulator/tt.c
+++ b/simulator/tt.c
@@ -83,7 +83,8 @@ void select_dash_screen(uint8_t screen) {
 }
 
 void print_dashboard_value(uint8_t index, int16_t value) {
-    printf("PRINT_DASHBOARD_VALUE  index:%" PRIu8 " value:%" PRId16, index, value);
+    printf("PRINT_DASHBOARD_VALUE  index:%" PRIu8 " value:%" PRId16, index,
+           value);
     printf("\n");
 }
 

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -614,6 +614,7 @@
         "TI.PRM.N"         => { MATCH_OP(E_OP_TI_PRM_N); };
         "TI.PRM.SCALE"     => { MATCH_OP(E_OP_TI_PRM_SCALE); };
         "TI.PRM.MAP"       => { MATCH_OP(E_OP_TI_PRM_MAP); };
+        "TI.PRM.CALIB"     => { MATCH_OP(E_OP_TI_PRM_CALIB); };
         "TI.PRM.INIT"      => { MATCH_OP(E_OP_TI_PRM_INIT); };
 
         # fader

--- a/src/ops/maths.c
+++ b/src/ops/maths.c
@@ -838,14 +838,14 @@ static void op_AND_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
                        exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
-    cs_push(cs, (a > 0) && (b > 0));
+    cs_push(cs, a && b);
 }
 
 static void op_OR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
                       exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
-    cs_push(cs, (a > 0) || (b > 0));
+    cs_push(cs, a || b);
 }
 
 static void op_AND3_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
@@ -853,7 +853,7 @@ static void op_AND3_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
     int16_t c = cs_pop(cs);
-    cs_push(cs, (a > 0) && (b > 0) && (c > 0));
+    cs_push(cs, a && b && c);
 }
 
 static void op_OR3_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
@@ -861,7 +861,7 @@ static void op_OR3_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
     int16_t c = cs_pop(cs);
-    cs_push(cs, (a > 0) || (b > 0) || (c > 0));
+    cs_push(cs, a || b || c);
 }
 
 static void op_AND4_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
@@ -870,7 +870,7 @@ static void op_AND4_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     int16_t b = cs_pop(cs);
     int16_t c = cs_pop(cs);
     int16_t d = cs_pop(cs);
-    cs_push(cs, (a > 0) && (b > 0) && (c > 0) && (d > 0));
+    cs_push(cs, a && b && c && d);
 }
 
 static void op_OR4_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
@@ -879,7 +879,7 @@ static void op_OR4_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     int16_t b = cs_pop(cs);
     int16_t c = cs_pop(cs);
     int16_t d = cs_pop(cs);
-    cs_push(cs, (a > 0) || (b > 0) || (c > 0) || (d > 0));
+    cs_push(cs, a || b || c || d);
 }
 
 static void op_JI_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -231,7 +231,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     &op_TI_PARAM_INIT, &op_TI_IN_INIT, &op_TI_INIT,
 
     &op_TI_PRM, &op_TI_PRM_QT, &op_TI_PRM_N, &op_TI_PRM_SCALE, &op_TI_PRM_MAP,
-    &op_TI_PRM_INIT,
+    &op_TI_PRM_CALIB, &op_TI_PRM_INIT,
 
     // fader
     &op_FADER, &op_FADER_SCALE, &op_FADER_CAL_MIN, &op_FADER_CAL_MAX,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -601,6 +601,7 @@ typedef enum {
     E_OP_TI_PRM_N,
     E_OP_TI_PRM_SCALE,
     E_OP_TI_PRM_MAP,
+    E_OP_TI_PRM_CALIB,
     E_OP_TI_PRM_INIT,
     E_OP_FADER,
     E_OP_FADER_SCALE,

--- a/src/ops/telex.c
+++ b/src/ops/telex.c
@@ -349,6 +349,7 @@ const tele_op_t op_TI_PRM_QT          = MAKE_ALIAS_OP(TI.PRM.QT         , op_TI_
 const tele_op_t op_TI_PRM_N           = MAKE_ALIAS_OP(TI.PRM.N          , op_TI_PARAM_N_get         , NULL, 1, true);
 const tele_op_t op_TI_PRM_SCALE       = MAKE_ALIAS_OP(TI.PRM.SCALE      , op_TI_PARAM_SCALE_get     , NULL, 2, false);
 const tele_op_t op_TI_PRM_MAP         = MAKE_ALIAS_OP(TI.PRM.MAP        , op_TI_PARAM_MAP_get       , NULL, 3, false);
+const tele_op_t op_TI_PRM_CALIB       = MAKE_ALIAS_OP(TI.PRM.CALIB      , op_TI_PARAM_CALIB_get     , NULL, 2, false);
 const tele_op_t op_TI_PRM_INIT        = MAKE_ALIAS_OP(TI.PRM.INIT       , op_TI_PARAM_INIT_get      , NULL, 1, false);
 
 // clang-format on

--- a/src/ops/telex.h
+++ b/src/ops/telex.h
@@ -132,6 +132,7 @@ extern const tele_op_t op_TI_PRM_QT;
 extern const tele_op_t op_TI_PRM_N;
 extern const tele_op_t op_TI_PRM_SCALE;
 extern const tele_op_t op_TI_PRM_MAP;
+extern const tele_op_t op_TI_PRM_CALIB;
 extern const tele_op_t op_TI_PRM_INIT;
 
 // helpers

--- a/tests/main.c
+++ b/tests/main.c
@@ -31,7 +31,7 @@ void tele_kill() {}
 void tele_mute() {}
 void tele_vars_updated() {}
 void tele_profile_script(size_t s) {}
-void tele_profile_delay(uint8_t d)  {}
+void tele_profile_delay(uint8_t d) {}
 bool tele_get_input_state(uint8_t n) {
     return false;
 }


### PR DESCRIPTION
#### What does this PR do?

several changes based on 4.0.0 beta testing:

- added missing entries to changelog and what's new
- logical operators should treat all non zero values as `true`, not just positive values
- better rendering for fine grid faders
- fixed `SCENE` crashing if parameter was out of bounds
- added alias `TI.PRM.CALIB` (was already in the docs)

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-4-0-0-pre-release-beta-ready-for-testing/45871

#### How should this be manually tested?

for logical ops, try `&& -1 -1` and `|| -1 -1` - both should return `true`
for `SCENE`, try executing with parameter out of 0..31 bounds

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
