### PR TITLE
don't allow out-of-range scenes to be selected from SCENE OP

### DIFF
--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -1,4 +1,5 @@
 #include "ops/controlflow.h"
+#include "../module/flash.h"
 
 #include "helpers.h"
 #include "random.h"
@@ -221,6 +222,9 @@ static void op_SCENE_get(const void *NOTUSED(data), scene_state_t *ss,
 static void op_SCENE_set(const void *NOTUSED(data), scene_state_t *ss,
                          exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t scene = cs_pop(cs);
+    if (scene < 0) { scene = 0; }
+    if (scene >= SCENE_SLOTS) { scene = SCENE_SLOTS - 1; }
+
     if (!ss->initializing) {
         ss->variables.scene = scene;
         tele_scene(scene, 1, 1);

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -234,6 +234,9 @@ static void op_SCENE_set(const void *NOTUSED(data), scene_state_t *ss,
 static void op_SCENE_G_get(const void *NOTUSED(data), scene_state_t *ss,
                            exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t scene = cs_pop(cs);
+    if (scene < 0) { scene = 0; }
+    if (scene >= SCENE_SLOTS) { scene = SCENE_SLOTS - 1; }
+
     if (!ss->initializing) {
         ss->variables.scene = scene;
         tele_scene(scene, 0, 1);
@@ -243,6 +246,9 @@ static void op_SCENE_G_get(const void *NOTUSED(data), scene_state_t *ss,
 static void op_SCENE_P_get(const void *NOTUSED(data), scene_state_t *ss,
                            exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t scene = cs_pop(cs);
+    if (scene < 0) { scene = 0; }
+    if (scene >= SCENE_SLOTS) { scene = SCENE_SLOTS - 1; }
+
     if (!ss->initializing) {
         ss->variables.scene = scene;
         tele_scene(scene, 1, 0);


### PR DESCRIPTION
#### What does this PR do?
Protect scene from being out of range (negative or larger than SCENE_SLOTS -1)

#### Provide links to any related discussion on [lines](https://llllllll.co/).

#### How should this be manually tested?
SCENE -1 (or smaller) should change to scene 0
SCENE 32 (or larger) should change to scene 31

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [ ] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [ ] run `make format` on each commit
* [ x] run tests
