### PR TITLE
Remove duplicate Disting cheatsheet section

### DIFF
--- a/utils/cheatsheet.py
+++ b/utils/cheatsheet.py
@@ -77,7 +77,6 @@ OPS_SECTIONS = [
     ("wslashdelay",   "W/2.0 delay",   False),
     ("wslashsynth",   "W/2.0 synth",   False),
     ("wslashtape",    "W/2.0 tape",    False),
-    ("disting",       "Disting EX",    False),
     ("crow",          "Crow",          False)
 ]
 


### PR DESCRIPTION
#### What does this PR do?
Just removes duplicate cheatsheet section

#### I have,
* [ ] updated `CHANGELOG.md` and `whats_new.md`  # would you like me to for such a small change?
* [n/a] updated the documentation
* [n/a] updated `help_mode.c` (if applicable)
* [n/a] run `make format` on each commit
* [n/a] run tests # docs still build fine locally (debian)
