### PR TITLE
Improve page load time in Chrome/Safari by reducing forced reflow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would only execute 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
 

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -15,7 +15,7 @@ teletype.pdf: $(wildcard *.md ops/*.md ops/*.toml) \
 	../utils/docs.py teletype.pdf
 
 teletype.html: $(wildcard *.md ops/*.md ops/*.toml) \
-		../utils/docs.py ../CHANGELOG.md
+		../utils/docs.py ../CHANGELOG.md $(wildcard ../utils/templates/*)
 	../utils/docs.py teletype.html
 
 cheatsheet/include.tex: $(wildcard ops/*.toml) ../utils/cheatsheet.py

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would execute only 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
 

--- a/utils/templates/template.html
+++ b/utils/templates/template.html
@@ -254,25 +254,21 @@
                 }
             };
 
-            var showMainContent = function () {
+            // handler for navigating to a new nav link
+            var navToSection = function () {
                 // for phone-size screens, navigation pane should
                 // hide as soon as a nav element is clicked
                 if (window.innerWidth < 700) {
                     hidden = false;
                     toggleNavigationArea();
                 }
-
-                // don't show main content until after all navigation changes have
-                // been made to make sure hash links navigate to the right place
-                document.getElementsByClassName("Content-inner")[0]
-                    .classList.remove("Content-inner--hidden");
                 if (window.location.hash) {
                     window.location = window.location.hash;
                 }
             }
 
-            // handler for navigating to a new nav link
-            var navToSection = function () {
+
+            var onFirstLoad = function () {
                 // All non-internal links should open new tab/window
                 var linksToNewTab = function () {
                     var aTags = document.getElementsByTagName("a");
@@ -286,10 +282,10 @@
                 // Fix <br/> issue with code blocks
                 // As well as issue where multi-line code blocks non-first
                 // lines were starting with spaces
-                var fixBr = function () {
+                var fixCodeTagWhitespace = function () {
                     var codeTags = document.getElementsByTagName("code");
                     for (var i = 0; i < codeTags.length; i++) {
-                        var breaks = codeTags[i].innerText.split("<br/>");
+                        var breaks = codeTags[i].textContent.split("<br/>");
                         for (var j = 0; j < breaks.length; j++) {
                             if (breaks[j].split("\n").length > 1) {
                                 splitBreak = breaks[j].split("\n");
@@ -300,24 +296,28 @@
                             }
                         }
                         if (breaks.length > 1) {
-                            codeTags[i].innerText = breaks
-                                .slice(1, breaks.length - 1).join("\n");
-                            codeTags[i].outerHTML = "<pre><code>" + codeTags[i].innerText + "</code></pre>";
+                            var str = breaks.slice(1, breaks.length - 1).join("\n");
+                            codeTags[i].outerHTML = "<pre><code>" + str + "</code></pre>";
                         } else {
-                            codeTags[i].innerText = breaks;
+                            codeTags[i].textContent = breaks;
                         }
                     }
                 };
 
-                showMainContent();
                 linksToNewTab();
-                fixBr();
+                fixCodeTagWhitespace();
+               
+                // don't show main content until after all navigation changes and
+                // DOM modifications have been made, to prevent unnecessary reflows
+                // and to make sure hash links navigate to the right place
+                document.getElementsByClassName("Content-inner")[0]
+                    .classList.remove("Content-inner--hidden");
             };
 
             // this makes back button work for navigating between links
             var changedHashHandler = function () {
                 updateAnchor();
-                showMainContent();
+                navToSection();
             };
 
             var navActionContainer = document
@@ -332,7 +332,7 @@
             updateAnchor();
             navActionContainer.onclick = toggleNavigationArea;
             window.onhashchange = changedHashHandler;
-            window.onload = navToSection;
+            window.onload = onFirstLoad;
         </script>
     </body>
 </html>


### PR DESCRIPTION
#### What does this PR do?

On some browsers (Chrome and Safari, but not Firefox) the Teletype manual has started to take up to 20 seconds to render the main content area after the page loads.

This rearranges some of the JS code in the HTML version of the manual to reduce reflow and improve the perceived time to load the page. Specifically, it:
* manipulates `textContent` rather than `innerText` to avoid forcing a reflow
* delays unhiding the main content area until all DOM modifications are complete, further preventing reflow
* renames some of the functions to reflect their current behavior

With the profiler on, in current Chrome 92.0.4515.159/Win10, this drops the time to final paint from around 20s to around 700ms.

#### How should this be manually tested?

1. Build the docs
2. Open `teletype.html` in Chrome 92 or Safari/iOS 14.71
3. Observe that the page renders in <1s and all code tags are rendered correctly

#### Any background context you want to provide?

This furthers the work begun in #217, which eliminated the reflow-induced delay from section navigation and isolated it to just the initial load.

#### I have,
* [X] updated `CHANGELOG.md` and `whats_new.md`
* [X] updated the documentation
