### PR TITLE
Making PROB slightly more useful

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -55,3 +55,7 @@ __pycache__/
 /docs/cheatsheet/*
 !/docs/cheatsheet/cheatsheet.tex
 /docs/testServe/
+
+# Jet Brains
+.idea
+*.iml

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,9 @@
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would only execute 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
-
+- **NEW**: `PROB` accepts an `ELSE` condition
+- **NEW**: alias `PRB` for `PROB`
+- 
 ## v4.0.0
 
 - **FIX**: `LAST SCRIPT` in live mode gives time since init script was run

--- a/docs/ops/controlflow.toml
+++ b/docs/ops/controlflow.toml
@@ -4,7 +4,7 @@ short = "if `x` is not zero execute command"
 description = """
 If `x` is not zero execute command
 
-#### Advanced `IF` / `ELIF` / `ELSE` usage
+#### Advanced `IF` / 'PROB' / `ELIF` / `ELSE` usage
 
   1. Intermediate statements always run
 
@@ -15,7 +15,7 @@ If `x` is not zero execute command
     ELSE: TR.P 2   => else branch runs because of the previous IF
     ```
 
-  2. `ELSE` without an `IF`
+  2. `ELSE` without an `IF` / 'PROB'
 
     ```text
     SCRIPT 1:
@@ -23,7 +23,7 @@ If `x` is not zero execute command
     ```
 
 
-  3. `ELIF` without an `IF`
+  3. `ELIF` without an `IF` / 'PROB'
 
     ```text
     SCRIPT 1:
@@ -56,11 +56,11 @@ If `x` is not zero execute command
 
 [ELIF]
 prototype = "ELIF x: ..."
-short = "if all previous `IF` / `ELIF` fail, and `x` is not zero, execute command"
+short = "if all previous `IF` / `ELIF` / 'PROB' fail, and `x` is not zero, execute command"
 
 [ELSE]
 prototype = "ELSE: ..."
-short = "if all previous `IF` / `ELIF` fail, excute command"
+short = "if all previous `IF` / `ELIF` / 'PROB' fail, excute command"
 
 [L]
 prototype = "L x y: ..."
@@ -155,6 +155,7 @@ Negative numbers will synchronize to to the divisor value, such that `SYNC -1` c
 
 [PROB]
 prototype = "PROB x: ..."
+aliases = ["PRB"]
 short = "potentially execute command with probability `x` (0-100)"
 
 [SCRIPT]

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -5,6 +5,8 @@
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would execute only 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
+- **NEW**: `PROB` accepts an `ELSE` condition
+- **NEW**: alias `PRB` for `PROB`
 
 ## v4.0.0
 

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -897,6 +897,7 @@
 
         # delay
         "PROB"        => { MATCH_MOD(E_MOD_PROB); };
+        "PRB"        => { MATCH_MOD(E_MOD_PRB); };
         "DEL"         => { MATCH_MOD(E_MOD_DEL); };
         "DEL.X"       => { MATCH_MOD(E_MOD_DEL_X); };
         "DEL.R"       => { MATCH_MOD(E_MOD_DEL_R); };

--- a/src/ops/controlflow.c
+++ b/src/ops/controlflow.c
@@ -57,6 +57,7 @@ static void op_SYNC_get(const void *data, scene_state_t *ss, exec_state_t *es,
 
 // clang-format off
 const tele_mod_t mod_PROB = MAKE_MOD(PROB, mod_PROB_func, 1);
+const tele_mod_t mod_PRB = MAKE_MOD(PRB, mod_PROB_func, 1);
 const tele_mod_t mod_IF = MAKE_MOD(IF, mod_IF_func, 1);
 const tele_mod_t mod_ELIF = MAKE_MOD(ELIF, mod_ELIF_func, 1);
 const tele_mod_t mod_ELSE = MAKE_MOD(ELSE, mod_ELSE_func, 0);
@@ -86,7 +87,11 @@ static void mod_PROB_func(scene_state_t *ss, exec_state_t *es,
     int16_t a = cs_pop(cs);
     random_state_t *r = &ss->rand_states.s.prob.rand;
 
-    if (random_next(r) % 100 < a) { process_command(ss, es, post_command); }
+    es_variables(es)->if_else_condition = false;
+    if (random_next(r) % 100 < a) {
+        es_variables(es)->if_else_condition = true;
+        process_command(ss, es, post_command);
+    }
 }
 
 static void mod_IF_func(scene_state_t *ss, exec_state_t *es,

--- a/src/ops/controlflow.h
+++ b/src/ops/controlflow.h
@@ -4,6 +4,7 @@
 #include "ops/op.h"
 
 extern const tele_mod_t mod_PROB;
+extern const tele_mod_t mod_PRB;
 extern const tele_mod_t mod_IF;
 extern const tele_mod_t mod_ELIF;
 extern const tele_mod_t mod_ELSE;

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -293,7 +293,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
 const tele_mod_t *tele_mods[E_MOD__LENGTH] = {
     // controlflow
     &mod_IF, &mod_ELIF, &mod_ELSE, &mod_L, &mod_W, &mod_EVERY, &mod_EV,
-    &mod_SKIP, &mod_OTHER, &mod_PROB,
+    &mod_SKIP, &mod_OTHER, &mod_PROB, &mod_PRB,
 
     // delay
     &mod_DEL, &mod_DEL_X, &mod_DEL_R, &mod_DEL_G, &mod_DEL_B,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -817,6 +817,7 @@ typedef enum {
     E_MOD_SKIP,
     E_MOD_OTHER,
     E_MOD_PROB,
+    E_MOD_PRB,
     E_MOD_DEL,
     E_MOD_DEL_X,
     E_MOD_DEL_R,


### PR DESCRIPTION
#### What does this PR do?

Adds Functionality to the following

- `PRB` is now an alias of `PROB`

Having the extra character helps when createing complex patches based on Probability

`PROB` can now use the `ELSE` statement

A common use case is to use a Bernoulli gate.  What this means is that it either goes to A OR to B based on a weighted coin toss

example/. (60% chance of triggering 1, otherwise trigger 2)

```
PRB 60: TR.P 1
ELSE: TR.P 2
```

#### How should this be manually tested?

See example above

#### I have,
* [ X] updated `CHANGELOG.md` and `whats_new.md`
* [X ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [X ] run `make format` on each commit
* [X ] run tests
