### PR TITLE
Buffer each command line in process_command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- *FIX*: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would only execute 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- *FIX*: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would execute only 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer

--- a/src/teletype.c
+++ b/src/teletype.c
@@ -203,17 +203,20 @@ process_result_t run_command(scene_state_t *ss, const tele_command_t *cmd) {
 
 // run a single command inside a given exec_state
 process_result_t process_command(scene_state_t *ss, exec_state_t *es,
-                                 const tele_command_t *c) {
+                                 const tele_command_t *cmd) {
     command_state_t cs;
     cs_init(&cs);  // initialise this here as well as inside the loop, in case
                    // the command has 0 length
+
+    tele_command_t  c;
+    copy_command(&c, cmd);
 
     // 1. Do we have a PRE seperator?
     // ------------------------------
     // if we do then only process the PRE part, the MOD will determine if the
     // POST should be run and take care of running it
     ssize_t start_idx = 0;
-    ssize_t end_idx = c->separator == -1 ? c->length : c->separator;
+    ssize_t end_idx = c.separator == -1 ? c.length : c.separator;
 
     // 2. Determine the location of all the SUB commands
     // -------------------------------------------------
@@ -226,9 +229,9 @@ process_result_t process_command(scene_state_t *ss, exec_state_t *es,
     ssize_t sub_len = 0;
     ssize_t sub_start = 0;
 
-    // iterate through c->data to find all the SUB_SEPs and add to the array
+    // iterate through c.data to find all the SUB_SEPs and add to the array
     for (ssize_t idx = start_idx; idx < end_idx; idx++) {
-        tele_word_t word_type = c->data[idx].tag;
+        tele_word_t word_type = c.data[idx].tag;
         if (word_type == SUB_SEP && idx > sub_start) {
             subs[sub_len].start = sub_start;
             subs[sub_len].end = idx - 1;
@@ -260,8 +263,8 @@ process_result_t process_command(scene_state_t *ss, exec_state_t *es,
         // as we are using a stack based language, we must process commands from
         // right to left
         for (ssize_t idx = sub_end; idx >= sub_start; idx--) {
-            const tele_word_t word_type = c->data[idx].tag;
-            const int16_t word_value = c->data[idx].value;
+            const tele_word_t word_type = c.data[idx].tag;
+            const int16_t word_value = c.data[idx].value;
 
             if (word_type == NUMBER || word_type == XNUMBER ||
                 word_type == BNUMBER || word_type == RNUMBER) {
@@ -281,7 +284,7 @@ process_result_t process_command(scene_state_t *ss, exec_state_t *es,
             else if (word_type == MOD) {
                 tele_command_t post_command;
                 post_command.comment = false;
-                copy_post_command(&post_command, c);
+                copy_post_command(&post_command, &c);
                 tele_mods[word_value]->func(ss, es, &cs, &post_command);
             }
         }

--- a/src/teletype.c
+++ b/src/teletype.c
@@ -208,7 +208,7 @@ process_result_t process_command(scene_state_t *ss, exec_state_t *es,
     cs_init(&cs);  // initialise this here as well as inside the loop, in case
                    // the command has 0 length
 
-    tele_command_t  c;
+    tele_command_t c;
     copy_command(&c, cmd);
 
     // 1. Do we have a PRE seperator?

--- a/src/teletype.h
+++ b/src/teletype.h
@@ -42,7 +42,7 @@ process_result_t run_script_with_exec_state(scene_state_t *ss, exec_state_t *es,
                                             size_t script_no);
 process_result_t run_command(scene_state_t *ss, const tele_command_t *cmd);
 process_result_t process_command(scene_state_t *ss, exec_state_t *es,
-                                 const tele_command_t *c);
+                                 const tele_command_t *cmd);
 
 void tele_tick(scene_state_t *ss, uint8_t);
 


### PR DESCRIPTION
#### What does this PR do?

This change stores the currently executing command in a local buffer during each call to `process_command`.  This ensures that when the scene changes, the operation map in `process_command` still points into the same code upon which it was based.  In this way we avoid undefined behavior when the global scene data is replaced while a command is running (i.e., when `SCENE` is executed).  Changing scenes from while code is running is still full of surprises, but they are well-defined.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-scene-x-op-users-of-that-op-chime-in/45833/23?u=3-foot-1

#### How should this be manually tested?

Run the scenes in the cited lines thread before and after applying the PR.  Before the change, A will be 9 and C will be 7.  After the change, A will be 18 and C will remain unchanged.

#### Any background context you want to provide?

Extensive discussion in the_dev_zone on the Teletype Studies discord.

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [X] run tests
