### PR TITLE
fix EX.LP op

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,10 +2,11 @@
 
 ## v4.0.x
 
-- *FIX*: cache currently-running commands to avoid corruption during SCENE ops.
+- **FIX**: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would only execute 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
+- **FIX**: fix `EX.LP` not returning correct values
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2,10 +2,11 @@
 
 ## v4.0.x
 
-- *FIX*: cache currently-running commands to avoid corruption during SCENE ops.
+- **FIX**: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would execute only 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
+- **FIX**: fix `EX.LP` not returning correct values
 
 ## v4.0.0
 

--- a/src/ops/disting.c
+++ b/src/ops/disting.c
@@ -690,7 +690,7 @@ static void op_EX_LP_get(const void *NOTUSED(data), scene_state_t *ss,
         return;
     }
 
-    cs_push(cs, get_looper_state(loop) & 0xb1111);
+    cs_push(cs, get_looper_state(loop) & 0b1111);
 }
 
 static void op_EX_LP_REVQ_get(const void *NOTUSED(data), scene_state_t *ss,


### PR DESCRIPTION
#### What does this PR do?

fixes `EX.LP` not returning correct values

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-disting-ex-integration/33929/116

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [x] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
