### PR TITLE
Insert cv and param in tracker mode

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,7 @@
 - **FIX**: `PROB 100` would only execute 99.01% of the time.
 - **FIX**: some `G.FDR` configurations caused incorrect rendering in grid visualizer
 - **FIX**: fix `EX.LP` not returning correct values
+- **NEW**: `i` and `p` insert values from CV input and param knob in tracker mode
 
 ## v4.0.0
 

--- a/docs/keys.md
+++ b/docs/keys.md
@@ -132,6 +132,8 @@ The tracker mode clipboard is independent of text and code clipboard.
 | **`shift-2`** (`@`)     | toggle turtle display marker (`<`)                                                    |
 | **`ctrl-alt`**          | insert knob value scaled to 0..31                                                     |
 | **`ctrl-shift`**        | insert knob value scaled to 0..1023                                                   |
+| **`p`**                 | insert knob value scaled using `PARAM.SCALE` settings                                 |
+| **`i`**                 | insert CV in value scaled using `IN.SCALE` settings                                   |
 
 ## Preset read mode
 

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -91,7 +91,9 @@ const char* help1[HELP1_LENGTH] = { "1/16 HELP",
                                     "SH-S|SET START",
                                     "SH-E|SET END",
                                     "ALT-L,S,E|JUMP",
-                                    "SHIFT-2|SHOW/HIDE TURTLE" };
+                                    "SHIFT-2|SHOW/HIDE TURTLE",
+                                    "I|SET TO CV INPUT",
+                                    "P|SET TO PARAM KNOB" };
 
 #define HELP2_LENGTH 25
 const char* help2[HELP2_LENGTH] = { "2/16 VARIABLES",

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -20,7 +20,7 @@
 
 // clang-format off
 
-#define HELP1_LENGTH 71
+#define HELP1_LENGTH 73
 const char* help1[HELP1_LENGTH] = { "1/16 HELP",
                                     "[ ] NAVIGATE HELP PAGES",
                                     "UP/DOWN TO SCROLL",

--- a/module/pattern_mode.c
+++ b/module/pattern_mode.c
@@ -486,6 +486,18 @@ void process_pattern_keys(uint8_t k, uint8_t m, bool is_held_key) {
         }
         dirty = true;
     }
+    // I: set to CV input
+    else if (match_no_mod(m, k, HID_I)) {
+        int16_t in_value = ss_get_in(&scene_state);
+        ss_set_pattern_val(&scene_state, pattern, base + offset, in_value);
+        dirty = true;
+    }
+    // P: set to param input
+    else if (match_no_mod(m, k, HID_P)) {
+        int16_t param_value = ss_get_param(&scene_state);
+        ss_set_pattern_val(&scene_state, pattern, base + offset, param_value);
+        dirty = true;
+    }
     if (!editing_number) edit_negative = false;
 }
 


### PR DESCRIPTION
#### What does this PR do?
Adds data to patterns using CV input and param values, when in tracker view. Respects settings for IN.SCALE and PARAM.SCALE.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

#### How should this be manually tested?
Go into tracker mode, move param knob while pressing `p`. Supply CV at input while pressing `i`

#### Any background context you want to provide?
I was looking for quicker way to create sequences from a keyboard with CV out.


#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [X] updated `CHANGELOG.md` and `whats_new.md`
* [X] updated the documentation
* [X] updated `help_mode.c` (if applicable)
* [X] run `make format` on each commit
* [X] run tests
