### PR TITLE
Fix CROW_Q3 operation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- **FIX**: fix `CROW.Q3` calls `ii.self.query2` instead of `ii.self.query3`
 - **FIX**: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would only execute 99.01% of the time.

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- **FIX**: fix `CROW.Q3` calls `ii.self.query2` instead of `ii.self.query3`
 - **FIX**: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs
 - **FIX**: `PROB 100` would execute only 99.01% of the time.

--- a/src/ops/crow.c
+++ b/src/ops/crow.c
@@ -185,7 +185,7 @@ CR_PROTO_GET(op_CROW_Q3_get) {
     u16 b = cs_pop(cs);
     u16 c = cs_pop(cs);
     u8 d[] = {
-        CROW_QUERY2, a >> 8, a & 0xFF, b >> 8, b & 0xFF, c >> 8, c & 0xFF
+        CROW_QUERY3, a >> 8, a & 0xFF, b >> 8, b & 0xFF, c >> 8, c & 0xFF
     };
     tele_ii_tx(unit, d, 7);
     u8 r[2];


### PR DESCRIPTION
#### What does this PR do?

Corrects a typo that prevents the `CROW.Q3` op from working.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

#### How should this be manually tested?

Connect crow to teletype via i2c; set up a crow event handler that responds to `CROW.Q3` and produces visible output in druid; invoke `CROW.Q3` on teletype; observe that the event handler is called with the PR, but not on the unpatched main branch.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [ ] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [ ] run `make format` on each commit
* [ ] run tests
