### PR TITLE
Fix off-by-one error in P.ROT

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- **FIX**: fix off-by-one error in `P.ROT` understanding of pattern length
 - **FIX**: fix `CROW.Q3` calls `ii.self.query2` instead of `ii.self.query3`
 - **FIX**: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -2,6 +2,7 @@
 
 ## v4.0.x
 
+- **FIX**: fix off-by-one error in `P.ROT` understanding of pattern length
 - **FIX**: fix `CROW.Q3` calls `ii.self.query2` instead of `ii.self.query3`
 - **FIX**: cache currently-running commands to avoid corruption during SCENE ops.
 - **FIX**: delay when opening docs

--- a/src/ops/patterns.c
+++ b/src/ops/patterns.c
@@ -830,7 +830,7 @@ static void p_rotate(scene_state_t *ss, int16_t pn, int16_t shift) {
     int16_t start = ss_get_pattern_start(ss, pn);
     int16_t end = ss_get_pattern_end(ss, pn);
     if (end < start) { return; }
-    int16_t len = end - start;
+    int16_t len = end - start + 1;
 
     if (shift < 0) {
         shift = -shift;

--- a/tests/process_tests.c
+++ b/tests/process_tests.c
@@ -304,6 +304,62 @@ TEST test_blank_command() {
     PASS();
 }
 
+TEST test_P_ROT_1() {
+    scene_state_t ss;
+    ss_init(&ss);
+
+    char* prep1[3] = { "P.START 0", "P.END 3", "0"};
+    CHECK_CALL(process_helper_state(&ss, 3, prep1, 0));
+
+    char* prep2[5] = { "P 0 1", "P 1 2", "P 2 3", "P 3 4", "P P.END" };
+    CHECK_CALL(process_helper_state(&ss, 5, prep2, 4));
+
+    char* prep3[2] = { "L 4 63: P I -1", "P + 1 P.END" };
+    CHECK_CALL(process_helper_state(&ss, 2, prep3, -1));
+
+    char* test1[2] = { "P.ROT 1", "P 0" };
+    CHECK_CALL(process_helper_state(&ss, 2, test1, 4));
+
+    char* test2[1] = { "P 1" };
+    CHECK_CALL(process_helper_state(&ss, 1, test2, 1));
+
+    char* test3[1] = { "P 2" };
+    CHECK_CALL(process_helper_state(&ss, 1, test3, 2));
+
+    char* test4[1] = { "P 3" };
+    CHECK_CALL(process_helper_state(&ss, 1, test4, 3));
+
+    PASS();
+}
+
+TEST test_P_ROT_3() {
+    scene_state_t ss;
+    ss_init(&ss);
+
+    char* prep1[3] = { "P.START 0", "P.END 3", "0"};
+    CHECK_CALL(process_helper_state(&ss, 3, prep1, 0));
+
+    char* prep2[5] = { "P 0 1", "P 1 2", "P 2 3", "P 3 4", "P P.END" };
+    CHECK_CALL(process_helper_state(&ss, 5, prep2, 4));
+
+    char* prep3[2] = { "L 4 63: P I -1", "P + 1 P.END" };
+    CHECK_CALL(process_helper_state(&ss, 2, prep3, -1));
+
+    char* test1[2] = { "P.ROT 3", "P 0" };
+    CHECK_CALL(process_helper_state(&ss, 2, test1, 2));
+
+    char* test2[1] = { "P 1" };
+    CHECK_CALL(process_helper_state(&ss, 1, test2, 3));
+
+    char* test3[1] = { "P 2" };
+    CHECK_CALL(process_helper_state(&ss, 1, test3, 4));
+
+    char* test4[1] = { "P 3" };
+    CHECK_CALL(process_helper_state(&ss, 1, test4, 1));
+
+    PASS();
+}
+
 SUITE(process_suite) {
     RUN_TEST(test_numbers);
     RUN_TEST(test_ADD);
@@ -318,4 +374,6 @@ SUITE(process_suite) {
     RUN_TEST(test_X);
     RUN_TEST(test_sub_commands);
     RUN_TEST(test_blank_command);
+    RUN_TEST(test_P_ROT_1);
+    RUN_TEST(test_P_ROT_3);
 }


### PR DESCRIPTION
#### What does this PR do?

Fixes an error where `P.ROT n` does nothing when `n == P.END - P.START`.

I.e., if we have four values in a pattern:

```
0: 1
1: 2
2: 3
3: 4
```

and `P.START` is 0 and `P.END` is 3, `P.ROT 3` should result in:

```
0: 2
1: 3
2: 4
3: 1
```

Instead, it is a no-op.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-workflow-basics-and-questions/12392/1821

#### How should this be manually tested?

Create the pattern shown above and run `P.ROT 3`.

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [ ] run `make format` on each commit
* [x] run tests
