### PR TITLE
fix BPM rounding error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@
 - **FIX**: reset M timer when changing metro rate
 - **NEW**: new Drum Ops: `DR.T`, `DR.V`, `DR.P`
 - **NEW**: [I2C2MIDI](https://github.com/attowatt/i2c2midi) ops
+- **FIX**: fix BPM rounding error
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -16,6 +16,7 @@
 - **FIX**: reset M timer when changing metro rate
 - **NEW**: drum ops: `DR.P`, `DR.V`, `DR.TR`
 - **NEW**: [I2C2MIDI](https://github.com/attowatt/i2c2midi) ops
+- **FIX**: fix BPM rounding error
 
 ## v4.0.0
 

--- a/src/ops/maths.c
+++ b/src/ops/maths.c
@@ -1255,7 +1255,8 @@ static void op_BPM_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
     uint32_t ret;
     if (a < 2) a = 2;
     if (a > 1000) a = 1000;
-    ret = ((((uint32_t)(1 << 31)) / ((a << 20) / 60)) * 1000) >> 11;
+    ret = ((((uint32_t)(1 << 31)) / ((a << 20) / 60)) * 1000) >> 10;
+    ret = ret / 2 + (ret & 1); // rounding
     cs_push(cs, (int16_t)ret);
 }
 


### PR DESCRIPTION
#### What does this PR do?

fixes `BPM` op rounding error

#### How should this be manually tested?

execute `BPM 375`, it should return 160 instead of 159

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [ ] run `make format` on each commit
* [x] run tests
