### PR TITLE
Fix MIDI IN ops channel being off by 1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - **FIX**: fix BPM rounding error
 - **FIX**: support all line ending types for USB load
 - **FIX**: fix `STATE` not accounting for `DEVICE.FLIP`
+- **FIX**: fix MIDI IN ops channel number being off by 1
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -19,6 +19,7 @@
 - **FIX**: fix BPM rounding error
 - **FIX**: support all line ending types for USB load
 - **FIX**: fix `STATE` not accounting for `DEVICE.FLIP`
+- **FIX**: fix MIDI IN ops channel number being off by 1
 
 ## v4.0.0
 

--- a/src/ops/midi.c
+++ b/src/ops/midi.c
@@ -278,28 +278,31 @@ static void op_MI_CCV_get(const void *NOTUSED(data), scene_state_t *ss,
 
 static void op_MI_LCH_get(const void *NOTUSED(data), scene_state_t *ss,
                           exec_state_t *NOTUSED(es), command_state_t *cs) {
-    cs_push(cs, ss->midi.last_channel);
+    cs_push(cs, ss->midi.last_channel + 1);
 }
 
 static void op_MI_NCH_get(const void *NOTUSED(data), scene_state_t *ss,
                           exec_state_t *es, command_state_t *cs) {
     s16 i = es_variables(es)->i;
-    cs_push(cs,
-            i < 1 || i > ss->midi.on_count ? 0 : ss->midi.on_channel[i - 1]);
+    cs_push(cs, i < 1 || i > ss->midi.on_count
+                    ? 0
+                    : ss->midi.on_channel[i - 1] + 1);
 }
 
 static void op_MI_OCH_get(const void *NOTUSED(data), scene_state_t *ss,
                           exec_state_t *es, command_state_t *cs) {
     s16 i = es_variables(es)->i;
-    cs_push(cs,
-            i < 1 || i > ss->midi.off_count ? 0 : ss->midi.off_channel[i - 1]);
+    cs_push(cs, i < 1 || i > ss->midi.off_count
+                    ? 0
+                    : ss->midi.off_channel[i - 1] + 1);
 }
 
 static void op_MI_CCH_get(const void *NOTUSED(data), scene_state_t *ss,
                           exec_state_t *es, command_state_t *cs) {
     s16 i = es_variables(es)->i;
-    cs_push(cs,
-            i < 1 || i > ss->midi.cc_count ? 0 : ss->midi.cc_channel[i - 1]);
+    cs_push(cs, i < 1 || i > ss->midi.cc_count
+                    ? 0
+                    : ss->midi.cc_channel[i - 1] + 1);
 }
 
 static void op_MI_CLKD_get(const void *NOTUSED(data), scene_state_t *ss,


### PR DESCRIPTION
#### What does this PR do?

fixes the issue with MIDI IN ops returning 0-based channel number instead of 1-based.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-midi-in-ops/32868/138

#### How should this be manually tested?

connect a MIDI controller and confirm that the channel number matches the actual one.

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
