### PR TITLE
improve TR.P accuracy

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,8 @@
 - **FIX**: support all line ending types for USB load
 - **FIX**: fix `STATE` not accounting for `DEVICE.FLIP`
 - **FIX**: fix MIDI IN ops channel number being off by 1
+- **FIX**: improve `TR.P` accuracy
+- **FIX**: fix `KILL` not stopping TR pulses in progress
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -20,6 +20,8 @@
 - **FIX**: support all line ending types for USB load
 - **FIX**: fix `STATE` not accounting for `DEVICE.FLIP`
 - **FIX**: fix MIDI IN ops channel number being off by 1
+- **FIX**: improve `TR.P` accuracy
+- **FIX**: fix `KILL` not stopping TR pulses in progress
 
 ## v4.0.0
 

--- a/simulator/tt.c
+++ b/simulator/tt.c
@@ -30,6 +30,21 @@ void tele_tr(uint8_t i, int16_t v) {
     printf("\n");
 }
 
+void tele_tr_pulse(uint8_t i, int16_t time) {
+    printf("TR PULSE i:%" PRIu8 " time:%" PRId16, i, time);
+    printf("\n");
+}
+
+void tele_tr_pulse_clear(uint8_t i) {
+    printf("TR PULSE CLEAR i:%" PRIu8, i);
+    printf("\n");
+}
+
+void tele_tr_pulse_time(uint8_t i, int16_t time) {
+    printf("TR PULSE TIME i:%" PRIu8 " time:%" PRId16, i, time);
+    printf("\n");
+}
+
 void tele_cv(uint8_t i, int16_t v, uint8_t s) {
     printf("CV  i:%" PRIu8 " v:%" PRId16 " s:%" PRIu8, i, v, s);
     printf("\n");

--- a/src/ops/hardware.c
+++ b/src/ops/hardware.c
@@ -409,6 +409,7 @@ static void op_TR_TIME_set(const void *NOTUSED(data), scene_state_t *ss,
         return;
     else if (a < 4) {
         ss->variables.tr_time[a] = b;
+        tele_tr_pulse_time(a, b);
     }
     else if (a < 20) {
         uint8_t d[] = { II_ANSIBLE_TR_TIME, a & 0x3, b >> 8, b & 0xff };
@@ -447,8 +448,8 @@ static void op_TR_PULSE_get(const void *NOTUSED(data), scene_state_t *ss,
         int16_t time = ss->variables.tr_time[a];  // pulse time
         if (time <= 0) return;  // if time <= 0 don't do anything
         ss->variables.tr[a] = ss->variables.tr_pol[a];
-        ss->tr_pulse_timer[a] = time;  // set time
         tele_tr(a, ss->variables.tr[a]);
+        tele_tr_pulse(a, time);
     }
     else if (a < 20) {
         uint8_t d[] = { II_ANSIBLE_TR_PULSE, a & 0x3 };

--- a/src/ops/init.c
+++ b/src/ops/init.c
@@ -144,7 +144,7 @@ static void op_INIT_TR_get(const void *NOTUSED(data), scene_state_t *ss,
         ss->variables.tr[v] = 0;
         ss->variables.tr_pol[v] = 1;
         ss->variables.tr_time[v] = 100;
-        ss->tr_pulse_timer[v] = 0;
+        tele_tr_pulse_clear(v);
         tele_tr(v, 0);
     }
 }
@@ -156,7 +156,7 @@ static void op_INIT_TR_ALL_get(const void *NOTUSED(data), scene_state_t *ss,
         ss->variables.tr[i] = 0;
         ss->variables.tr_pol[i] = 1;
         ss->variables.tr_time[i] = 100;
-        ss->tr_pulse_timer[i] = 0;
+        tele_tr_pulse_clear(i);
         tele_tr(i, 0);
     }
 }

--- a/src/state.c
+++ b/src/state.c
@@ -17,7 +17,6 @@ void ss_init(scene_state_t *ss) {
     ss_rand_init(ss);
     ss_midi_init(ss);
     ss->delay.count = 0;
-    for (size_t i = 0; i < TR_COUNT; i++) { ss->tr_pulse_timer[i] = 0; }
     for (size_t i = 0; i < NB_NBX_SCALES; i++) {
         ss->variables.n_scale_bits[i] = bit_reverse(0b101011010101, 12);
         ss->variables.n_scale_root[i] = 0;

--- a/src/state.h
+++ b/src/state.h
@@ -261,7 +261,6 @@ typedef struct {
     scene_pattern_t patterns[PATTERN_COUNT];
     scene_delay_t delay;
     scene_stack_op_t stack_op;
-    int16_t tr_pulse_timer[TR_COUNT];
     scene_script_t scripts[TOTAL_SCRIPT_COUNT];
     scene_turtle_t turtle;
     bool every_last;

--- a/src/teletype.c
+++ b/src/teletype.c
@@ -18,7 +18,10 @@ bool processing_delays = false;
 // DELAY ////////////////////////////////////////////////////////
 
 void clear_delays(scene_state_t *ss) {
-    for (int16_t i = 0; i < TR_COUNT; i++) { ss->tr_pulse_timer[i] = 0; }
+    for (int16_t i = 0; i < TR_COUNT; i++) {
+        tele_tr_pulse_clear(i);
+        tele_tr_pulse_end(ss, i);
+    }
 
     for (int16_t i = 0; i < DELAY_SIZE; i++) { ss->delay.time[i] = 0; }
 
@@ -344,25 +347,11 @@ void tele_tick(scene_state_t *ss, uint8_t time) {
             }
         }
     }
+}
 
-    // process tr pulses
-    for (int16_t i = 0; i < TR_COUNT; i++) {
-        if (ss->tr_pulse_timer[i]) {
-            // prevent tr_pulse_timer from being greater than tr_time
-            int16_t tr_time = ss->variables.tr_time[i];
-            if (tr_time < 0) tr_time = 0;
-            if (ss->tr_pulse_timer[i] > tr_time)
-                ss->tr_pulse_timer[i] = tr_time;
-
-            ss->tr_pulse_timer[i] -= time;
-
-            if (ss->tr_pulse_timer[i] <= 0) {
-                ss->tr_pulse_timer[i] = 0;
-                ss->variables.tr[i] = ss->variables.tr_pol[i] == 0;
-                tele_tr(i, ss->variables.tr[i]);
-            }
-        }
-    }
+void tele_tr_pulse_end(scene_state_t *ss, uint8_t i) {
+    ss->variables.tr[i] = ss->variables.tr_pol[i] == 0;
+    tele_tr(i, ss->variables.tr[i]);
 }
 
 /////////////////////////////////////////////////////////////////

--- a/src/teletype.h
+++ b/src/teletype.h
@@ -47,6 +47,8 @@ void tele_tick(scene_state_t *ss, uint8_t);
 
 void clear_delays(scene_state_t *ss);
 
+void tele_tr_pulse_end(scene_state_t *ss, uint8_t i);
+
 const char *tele_error(error_t);
 
 #endif

--- a/src/teletype_io.h
+++ b/src/teletype_io.h
@@ -23,6 +23,9 @@ extern void tele_metro_updated(void);
 extern void tele_metro_reset(void);
 
 extern void tele_tr(uint8_t i, int16_t v);
+extern void tele_tr_pulse(uint8_t i, int16_t time);
+extern void tele_tr_pulse_clear(uint8_t i);
+extern void tele_tr_pulse_time(uint8_t i, int16_t time);
 extern void tele_cv(uint8_t i, int16_t v, uint8_t s);
 extern void tele_cv_slew(uint8_t i, int16_t v);
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -17,6 +17,9 @@ uint32_t tele_get_ticks() {
 void tele_metro_updated() {}
 void tele_metro_reset() {}
 void tele_tr(uint8_t i, int16_t v) {}
+void tele_tr_pulse(uint8_t i, int16_t time) {}
+void tele_tr_pulse_clear(uint8_t i) {}
+void tele_tr_pulse_time(uint8_t i, int16_t time) {}
 void tele_cv(uint8_t i, int16_t v, uint8_t s) {}
 void tele_cv_slew(uint8_t i, int16_t v) {}
 void tele_update_adc(uint8_t force) {}


### PR DESCRIPTION
#### What does this PR do?

previously, TR pulses were processed by `tele_tick` which gets triggered by a 10ms timer, which resulted in the actual pulse length being off by up to 9ms. this PR introduces dedicated timers for each TR output to improve the accuracy. as there are only 4 trigger outputs, i don't think adding 4 timers should make any impact.

additionally, i fixed a bug i discovered where killing delays would not restore TR outputs that had a pulse in progress.

#### How should this be manually tested?

i tested this with a scope and confirmed that the pulse time matches the one set with `TR.TIME`. also confirmed TR pulses work in general - triggering different outputs, changing the pulse time while a pulse is in progress, killing delays.

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [x] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
