### PR TITLE
CV.GET

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,6 @@
 # Changelog
 
-## v4.0.x
+## v5.0.0
 
 - **FIX**: fix off-by-one error in `P.ROT` understanding of pattern length
 - **FIX**: fix `CROW.Q3` calls `ii.self.query2` instead of `ii.self.query3`
@@ -26,6 +26,7 @@
 - **FIX**: fix `KILL` not stopping TR pulses in progress
 - **NEW**: new op: `SCALE0` / `SCL0`
 - **NEW**: new ops: `$F`, `$F1`, `$F2`, `$L`, `$L1`, `$L2`, `$S`, `$S1`, `$S2`, `I1`, `I2`, `FR`
+- **NEW**: new op: `CV.GET`
 
 ## v4.0.0
 

--- a/docs/ops/hardware.toml
+++ b/docs/ops/hardware.toml
@@ -24,6 +24,13 @@ description = """
 Set the CV value at output `x` bypassing any slew settings.
 """
 
+["CV.GET"]
+prototype = "CV.GET x"
+short = "Get current CV value"
+description = """
+Get the current CV value at output `x` with slew and offset applied.
+"""
+
 ["CV.SLEW"]
 prototype = "CV.SLEW x"
 prototype_set = "CV.SLEW x y"

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,6 +1,6 @@
 # Updates
 
-## v4.0.x
+## v5.0.0
 
 - **FIX**: fix off-by-one error in `P.ROT` understanding of pattern length
 - **FIX**: fix `CROW.Q3` calls `ii.self.query2` instead of `ii.self.query3`
@@ -24,6 +24,7 @@
 - **FIX**: fix `KILL` not stopping TR pulses in progress
 - **NEW**: new op: `SCALE0` / `SCL0`
 - **NEW**: new ops: `$F`, `$F1`, `$F2`, `$L`, `$L1`, `$L2`, `$S`, `$S1`, `$S2`, `I1`, `I2`, `FR`
+- **NEW**: new op: `CV.GET`
 
 ## v4.0.0
 

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -120,7 +120,7 @@ const char* help2[HELP2_LENGTH] = { "2/17 VARIABLES",
                                     "PRINT X",
                                     "    GET/PRINT VALUE" };
 
-#define HELP3_LENGTH 73
+#define HELP3_LENGTH 74
 const char* help3[HELP3_LENGTH] = { "3/17 PARAMETERS",
                                     " ",
                                     "TR A-D|SET TR VALUE (0,1)",
@@ -128,6 +128,7 @@ const char* help3[HELP3_LENGTH] = { "3/17 PARAMETERS",
                                     "CV 1-4|CV TARGET VALUE",
                                     "CV.SLEW 1-4|CV SLEW TIME (MS)",
                                     "CV.SET 1-4|SET CV (NO SLEW)",
+                                    "CV.GET 1-4|GET CURRENT CV",
                                     "CV.OFF 1-4|ADD CV OFFSET",
                                     " ",
                                     "IN|GET IN JACK VAL",

--- a/module/main.c
+++ b/module/main.c
@@ -1108,6 +1108,10 @@ void tele_cv_off(uint8_t i, int16_t v) {
     aout[i].off = v;
 }
 
+uint16_t tele_get_cv(uint8_t i) {
+    return aout[(device_config.flip ? 3 - i : i)].now;
+}
+
 void tele_update_adc(u8 force) {
     if (!force && get_ticks() == last_adc_tick) return;
     last_adc_tick = get_ticks();

--- a/simulator/tt.c
+++ b/simulator/tt.c
@@ -55,6 +55,12 @@ void tele_cv_slew(uint8_t i, int16_t v) {
     printf("\n");
 }
 
+uint16_t tele_get_cv(uint8_t i) {
+    printf("CV_GET  i:%" PRIu8, i);
+    printf("\n");
+    return 0;
+}
+
 void tele_update_adc(uint8_t force) {
     printf("UPDATE ADC force:%s", force ? "true" : "false");
     printf("\n");

--- a/src/match_token.rl
+++ b/src/match_token.rl
@@ -175,6 +175,7 @@
         "TR.TOG"      => { MATCH_OP(E_OP_TR_TOG); };
         "TR.PULSE"    => { MATCH_OP(E_OP_TR_PULSE); };
         "TR.P"        => { MATCH_OP(E_OP_TR_P); };
+        "CV.GET"      => { MATCH_OP(E_OP_CV_GET); };
         "CV.SET"      => { MATCH_OP(E_OP_CV_SET); };
         "MUTE"        => { MATCH_OP(E_OP_MUTE); };
         "STATE"       => { MATCH_OP(E_OP_STATE); };

--- a/src/ops/hardware.c
+++ b/src/ops/hardware.c
@@ -55,6 +55,8 @@ static void op_TR_TOG_get(const void *data, scene_state_t *ss, exec_state_t *es,
                           command_state_t *cs);
 static void op_TR_PULSE_get(const void *data, scene_state_t *ss,
                             exec_state_t *es, command_state_t *cs);
+static void op_CV_GET_get(const void *data, scene_state_t *ss, exec_state_t *es,
+                          command_state_t *cs);
 static void op_CV_SET_get(const void *data, scene_state_t *ss, exec_state_t *es,
                           command_state_t *cs);
 static void op_MUTE_get(const void *data, scene_state_t *ss, exec_state_t *es,
@@ -94,6 +96,7 @@ const tele_op_t op_TR_TIME  = MAKE_GET_SET_OP(TR.TIME , op_TR_TIME_get , op_TR_T
 const tele_op_t op_TR_TOG   = MAKE_GET_OP    (TR.TOG  , op_TR_TOG_get  , 1, false);
 const tele_op_t op_TR_PULSE = MAKE_GET_OP    (TR.PULSE, op_TR_PULSE_get, 1, false);
 const tele_op_t op_TR_P     = MAKE_ALIAS_OP  (TR.P    , op_TR_PULSE_get, NULL, 1, false);
+const tele_op_t op_CV_GET   = MAKE_GET_OP    (CV.GET  , op_CV_GET_get  , 1, true);
 const tele_op_t op_CV_SET   = MAKE_GET_OP    (CV.SET  , op_CV_SET_get  , 2, false);
 const tele_op_t op_MUTE     = MAKE_GET_SET_OP(MUTE    , op_MUTE_get    , op_MUTE_set   , 1, true);
 const tele_op_t op_STATE    = MAKE_GET_OP    (STATE   , op_STATE_get   , 1, true );
@@ -222,7 +225,6 @@ static void op_CV_OFF_set(const void *NOTUSED(data), scene_state_t *ss,
                           exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t a = cs_pop(cs);
     int16_t b = cs_pop(cs);
-    ss->variables.cv_off[a] = b;
     a--;
     if (a < 0)
         return;
@@ -456,6 +458,12 @@ static void op_TR_PULSE_get(const void *NOTUSED(data), scene_state_t *ss,
         uint8_t addr = II_ANSIBLE_ADDR + (((a - 4) >> 2) << 1);
         tele_ii_tx(addr, d, 2);
     }
+}
+
+static void op_CV_GET_get(const void *NOTUSED(data), scene_state_t *ss,
+                          exec_state_t *NOTUSED(es), command_state_t *cs) {
+    uint8_t i = cs_pop(cs) - 1;
+    cs_push(cs, i < 4 ? tele_get_cv(i) : 0);
 }
 
 static void op_CV_SET_get(const void *NOTUSED(data), scene_state_t *ss,

--- a/src/ops/hardware.h
+++ b/src/ops/hardware.h
@@ -23,6 +23,7 @@ extern const tele_op_t op_TR_TIME;
 extern const tele_op_t op_TR_TOG;
 extern const tele_op_t op_TR_PULSE;
 extern const tele_op_t op_TR_P;
+extern const tele_op_t op_CV_GET;
 extern const tele_op_t op_CV_SET;
 extern const tele_op_t op_MUTE;
 extern const tele_op_t op_STATE;

--- a/src/ops/op.c
+++ b/src/ops/op.c
@@ -85,7 +85,7 @@ const tele_op_t *tele_ops[E_OP__LENGTH] = {
     &op_TR_POL, &op_TR_TIME, &op_TR_TOG, &op_TR_PULSE, &op_TR_P, &op_CV_SET,
     &op_MUTE, &op_STATE, &op_DEVICE_FLIP, &op_LIVE_OFF, &op_LIVE_O,
     &op_LIVE_DASH, &op_LIVE_D, &op_LIVE_GRID, &op_LIVE_G, &op_LIVE_VARS,
-    &op_LIVE_V, &op_PRINT, &op_PRT,
+    &op_LIVE_V, &op_PRINT, &op_PRT, &op_CV_GET,
 
     // maths
     &op_ADD, &op_SUB, &op_MUL, &op_DIV, &op_MOD, &op_RAND, &op_RND, &op_RRAND,

--- a/src/ops/op_enum.h
+++ b/src/ops/op_enum.h
@@ -164,6 +164,7 @@ typedef enum {
     E_OP_LIVE_V,
     E_OP_PRINT,
     E_OP_PRT,
+    E_OP_CV_GET,
     E_OP_ADD,
     E_OP_SUB,
     E_OP_MUL,

--- a/src/teletype_io.h
+++ b/src/teletype_io.h
@@ -28,6 +28,7 @@ extern void tele_tr_pulse_clear(uint8_t i);
 extern void tele_tr_pulse_time(uint8_t i, int16_t time);
 extern void tele_cv(uint8_t i, int16_t v, uint8_t s);
 extern void tele_cv_slew(uint8_t i, int16_t v);
+extern uint16_t tele_get_cv(uint8_t i);
 
 extern void tele_update_adc(uint8_t force);
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -22,6 +22,9 @@ void tele_tr_pulse_clear(uint8_t i) {}
 void tele_tr_pulse_time(uint8_t i, int16_t time) {}
 void tele_cv(uint8_t i, int16_t v, uint8_t s) {}
 void tele_cv_slew(uint8_t i, int16_t v) {}
+uint16_t tele_get_cv(uint8_t i) {
+    return 0;
+}
 void tele_update_adc(uint8_t force) {}
 void tele_has_delays(bool i) {}
 void tele_has_stack(bool i) {}


### PR DESCRIPTION
#### What does this PR do?

adds `CV.GET` op - get the current CV value with slew and offset taken into account. this is essentially "get the real CV value at the output".

#### How should this be manually tested?

set slew time for CV output 1 to 10 sec, then execute `CV.SET 1 0` and `CV.SET 1 V 10`. while it's slewing, execute `CV.GET 1` repeatedly in live screen - it should return different values as the CV value is being slewed from 0 to V10.

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [x] updated the documentation
* [x] updated `help_mode.c` (if applicable)
* [x] run `make format` on each commit
* [x] run tests
