### PR TITLE
Enforce clang-format in CI

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -5,7 +5,7 @@ ColumnLimit: 80
 ---
 Language: Cpp
 
-AllowShortBlocksOnASingleLine: true
+AllowShortBlocksOnASingleLine: Always
 AllowShortCaseLabelsOnASingleLine: true
 AllowShortFunctionsOnASingleLine: Empty
 

--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -12,5 +12,3 @@
 * [ ] updated `CHANGELOG.md` and `whats_new.md`
 * [ ] updated the documentation
 * [ ] updated `help_mode.c` (if applicable)
-* [ ] run `make format` on each commit
-* [ ] run tests

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -10,6 +10,14 @@ on:
   workflow_dispatch:
 
 jobs:
+  clang-format:
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v3
+    - name: Run clang-format
+      run: |
+        curl -O https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
+        python ./run-clang-format.py -r module simulator src tests --style=file
   run-tests:
     runs-on: ubuntu-latest
     steps:

--- a/module/edit_mode.c
+++ b/module/edit_mode.c
@@ -436,9 +436,7 @@ uint8_t screen_refresh_edit() {
             }
             status = E_OK;
         }
-        else {
-            s[0] = 0;
-        }
+        else { s[0] = 0; }
 
         region_fill(&line[6], 0);
         font_string_region_clip(&line[6], s, 0, 0, 0x4, 0);

--- a/module/grid.c
+++ b/module/grid.c
@@ -224,12 +224,8 @@ void grid_set_control_mode(u8 control, u8 mode, scene_state_t *ss) {
         tt_mode = G_EDIT;
         tt_script = get_edit_script();
     }
-    else if (mode == M_PATTERN) {
-        tt_mode = G_TRACKER;
-    }
-    else if (mode == M_PRESET_W || mode == M_PRESET_R) {
-        tt_mode = G_PRESET;
-    }
+    else if (mode == M_PATTERN) { tt_mode = G_TRACKER; }
+    else if (mode == M_PRESET_W || mode == M_PRESET_R) { tt_mode = G_PRESET; }
     control_mode_on = control;
     grid_clear_held_keys();
     ss->grid.grid_dirty = 1;
@@ -509,9 +505,7 @@ static void restore_last_mode(scene_state_t *ss) {
         set_edit_mode_script(tt_script);
         set_mode(M_EDIT);
     }
-    else if (tt_mode == G_PRESET) {
-        set_mode(M_PRESET_R);
-    }
+    else if (tt_mode == G_PRESET) { set_mode(M_PRESET_R); }
     else if (tt_mode == G_LIVE_V) {
         set_mode(M_LIVE);
         set_live_submode(SUB_MODE_VARS);
@@ -578,9 +572,7 @@ static u8 grid_control_process_key(scene_state_t *ss, u8 x, u8 y, u8 z,
                         tracker_last = value;
                         value = 0;
                     }
-                    else {
-                        value = tracker_last ? tracker_last : 1;
-                    }
+                    else { value = tracker_last ? tracker_last : 1; }
                     ss_set_pattern_val(ss, tracker_x - 2, tracker_y + offset,
                                        value);
                 }
@@ -892,9 +884,7 @@ static u8 grid_control_process_key(scene_state_t *ss, u8 x, u8 y, u8 z,
                     variable_last = v[ve];
                     v[ve] = 0;
                 }
-                else {
-                    v[ve] = variable_last ? variable_last : 1;
-                }
+                else { v[ve] = variable_last ? variable_last : 1; }
             }
             variable_edit = 0;
             set_vars_updated();
@@ -987,12 +977,8 @@ static u8 grid_control_process_key(scene_state_t *ss, u8 x, u8 y, u8 z,
         if (!z) return 1;
 
         if (y == 3 && x == 6) { history_prev(); }
-        else if (y == 4 && x == 6) {
-            history_next();
-        }
-        else if (y == 4 && x == 7 && !from_held) {
-            execute_line();
-        }
+        else if (y == 4 && x == 6) { history_next(); }
+        else if (y == 4 && x == 7 && !from_held) { execute_line(); }
 
         return 1;
     }

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -1711,18 +1711,14 @@ void process_help_keys(uint8_t k, uint8_t m, bool is_held_key) {
     else if (match_ctrl(m, k, HID_F) || match_ctrl(m, k, HID_S)) {
         search_result = SEARCH_RESULT_NONE;
         if (search_mode == SEARCH_MODE_FWD) { search_mode = SEARCH_MODE_NONE; }
-        else {
-            search_mode = SEARCH_MODE_FWD;
-        }
+        else { search_mode = SEARCH_MODE_FWD; }
         dirty = true;
     }
     // C-r: search in reverse
     else if (match_ctrl(m, k, HID_R)) {
         search_result = SEARCH_RESULT_NONE;
         if (search_mode == SEARCH_MODE_REV) { search_mode = SEARCH_MODE_NONE; }
-        else {
-            search_mode = SEARCH_MODE_REV;
-        }
+        else { search_mode = SEARCH_MODE_REV; }
         dirty = true;
     }
     else if (search_mode != SEARCH_MODE_NONE) {

--- a/module/line_editor.c
+++ b/module/line_editor.c
@@ -71,9 +71,7 @@ bool line_editor_process_keys(line_editor_t *le, uint8_t k, uint8_t m,
             if (le->buffer[le->cursor - 1] == ' ') {
                 if (encountered_word) break;
             }
-            else {
-                encountered_word = true;
-            }
+            else { encountered_word = true; }
             le->cursor--;
         }
         return true;
@@ -85,9 +83,7 @@ bool line_editor_process_keys(line_editor_t *le, uint8_t k, uint8_t m,
             if (le->buffer[le->cursor] == ' ') {
                 if (encountered_word) break;
             }
-            else {
-                encountered_word = true;
-            }
+            else { encountered_word = true; }
             le->cursor++;
         }
         return true;
@@ -136,9 +132,7 @@ bool line_editor_process_keys(line_editor_t *le, uint8_t k, uint8_t m,
             if (le->buffer[le->cursor - 1] == ' ') {
                 if (encountered_word) break;
             }
-            else {
-                encountered_word = true;
-            }
+            else { encountered_word = true; }
             // Delete preceeding character by shifting buffer down.
             le->cursor--;
             for (size_t x = le->cursor; x < LINE_EDITOR_SIZE - 1; x++) {
@@ -156,9 +150,7 @@ bool line_editor_process_keys(line_editor_t *le, uint8_t k, uint8_t m,
             if (le->buffer[le->cursor] == ' ') {
                 if (encountered_word) break;
             }
-            else {
-                encountered_word = true;
-            }
+            else { encountered_word = true; }
             // Delete this character by shifting the buffer down.
             for (size_t x = le->cursor; x < LINE_EDITOR_SIZE - 1; ++x) {
                 le->buffer[x] = le->buffer[x + 1];

--- a/module/live_mode.c
+++ b/module/live_mode.c
@@ -570,9 +570,7 @@ void process_live_keys(uint8_t k, uint8_t m, bool is_held_key, bool is_release,
     // tilde: show the variables
     else if (match_no_mod(m, k, HID_TILDE)) {
         if (sub_mode == SUB_MODE_VARS) { sub_mode = SUB_MODE_OFF; }
-        else {
-            sub_mode = SUB_MODE_VARS;
-        }
+        else { sub_mode = SUB_MODE_VARS; }
         dirty = D_ALL;
     }
     // pass the key though to the line editor
@@ -774,9 +772,7 @@ uint8_t screen_refresh_live() {
             strncat(s, git_version, 35 - strlen(s));
             show_welcome_message = false;
         }
-        else {
-            s[0] = 0;
-        }
+        else { s[0] = 0; }
 
         region_fill(&line[6], 0);
         font_string_region_clip(&line[6], s, 0, 0, 0x4, 0);

--- a/module/main.c
+++ b/module/main.c
@@ -413,9 +413,7 @@ void handler_PollADC(int32_t data) {
         if (!deadzone || abs(preset - get_preset()) > 1)
             process_preset_r_preset(preset);
     }
-    else {
-        ss_set_param(&scene_state, adc[1] << 2);
-    }
+    else { ss_set_param(&scene_state, adc[1] << 2); }
 #ifdef TELETYPE_PROFILE
     profile_update(&prof_ADC);
 #endif
@@ -867,9 +865,7 @@ bool process_global_keys(uint8_t k, uint8_t m, bool is_held_key) {
     else if (match_no_mod(m, k, HID_ESCAPE)) {
         if (mode == M_PRESET_R)
             set_last_mode();
-        else {
-            set_mode(M_PRESET_R);
-        }
+        else { set_mode(M_PRESET_R); }
         return true;
     }
     // alt-<esc>: preset write mode
@@ -886,9 +882,7 @@ bool process_global_keys(uint8_t k, uint8_t m, bool is_held_key) {
     else if (match_shift_alt(m, k, HID_SLASH) || match_alt(m, k, HID_H)) {
         if (mode == M_HELP)
             set_last_mode();
-        else {
-            set_mode(M_HELP);
-        }
+        else { set_mode(M_HELP); }
         return true;
     }
     // <F1> through <F8>: run corresponding script
@@ -955,9 +949,7 @@ bool process_global_keys(uint8_t k, uint8_t m, bool is_held_key) {
         if (mode != M_LIVE) { set_mode(M_LIVE); }
         return true;
     }
-    else {
-        return false;
-    }
+    else { return false; }
 }
 
 
@@ -1068,9 +1060,7 @@ void tele_tr_pulse_time(uint8_t i, int16_t time) {
     u32 time_spent = trPulseTimer[i].ticks - trPulseTimer[i].ticksRemain;
     timer_set(&trPulseTimer[i], time);
     if (time_spent >= time) { timer_manual(&trPulseTimer[i]); }
-    else {
-        trPulseTimer[i].ticksRemain = time - time_spent;
-    }
+    else { trPulseTimer[i].ticksRemain = time - time_spent; }
 }
 
 void trPulseTimer_callback(void* obj) {

--- a/module/pattern_mode.c
+++ b/module/pattern_mode.c
@@ -80,9 +80,7 @@ void pattern_down() {
 static int16_t transpose_n_value(int16_t value, int8_t interval) {
     uint8_t last_note = 127;
     if (interval > last_note) { interval = last_note; }
-    else if (interval < -last_note) {
-        interval = -last_note;
-    }
+    else if (interval < -last_note) { interval = -last_note; }
     if (value > table_n[last_note]) {
         uint8_t idx = last_note;
         if (interval < 0) idx++;
@@ -95,9 +93,7 @@ static int16_t transpose_n_value(int16_t value, int8_t interval) {
             if (table_n[i] > value && interval > 0)
                 j--;  // quantize to lower note
             if (j > last_note) { j = j % last_note + 1; }
-            else if (j < 0) {
-                j = j + last_note + 1;
-            }
+            else if (j < 0) { j = j + last_note + 1; }
             new_value = table_n[j];
             break;
         }
@@ -133,9 +129,7 @@ void process_pattern_keys(uint8_t k, uint8_t m, bool is_held_key) {
         dirty = true;
     }
     // <up>: move up
-    else if (match_no_mod(m, k, HID_UP)) {
-        pattern_up();
-    }
+    else if (match_no_mod(m, k, HID_UP)) { pattern_up(); }
     // alt-<up>: move a page up
     else if (match_alt(m, k, HID_UP)) {
         editing_number = false;
@@ -213,29 +207,17 @@ void process_pattern_keys(uint8_t k, uint8_t m, bool is_held_key) {
         }
     }
     // alt-[: decrement by 1 semitone
-    else if (match_alt(m, k, HID_OPEN_BRACKET)) {
-        note_nudge(-1);
-    }
+    else if (match_alt(m, k, HID_OPEN_BRACKET)) { note_nudge(-1); }
     // alt-]: increment by 1 semitone
-    else if (match_alt(m, k, HID_CLOSE_BRACKET)) {
-        note_nudge(1);
-    }
+    else if (match_alt(m, k, HID_CLOSE_BRACKET)) { note_nudge(1); }
     // ctrl-[: decrement by a fifth (7 semitones)
-    else if (match_ctrl(m, k, HID_OPEN_BRACKET)) {
-        note_nudge(-7);
-    }
+    else if (match_ctrl(m, k, HID_OPEN_BRACKET)) { note_nudge(-7); }
     // ctrl-]: increment by a fifth (7 semitones)
-    else if (match_ctrl(m, k, HID_CLOSE_BRACKET)) {
-        note_nudge(7);
-    }
+    else if (match_ctrl(m, k, HID_CLOSE_BRACKET)) { note_nudge(7); }
     // sh-[: decrement by 1 octave
-    else if (match_shift(m, k, HID_OPEN_BRACKET)) {
-        note_nudge(-12);
-    }
+    else if (match_shift(m, k, HID_OPEN_BRACKET)) { note_nudge(-12); }
     // sh-]: increment by 1 octave
-    else if (match_shift(m, k, HID_CLOSE_BRACKET)) {
-        note_nudge(12);
-    }
+    else if (match_shift(m, k, HID_CLOSE_BRACKET)) { note_nudge(12); }
     // alt-<0-9>: transpose up by numeric semitones
     else if (mod_only_alt(m) && k >= HID_1 && k <= HID_0) {
         uint8_t n = (k - HID_1 + 1);  // convert HID numbers to decimal,
@@ -441,9 +423,7 @@ void process_pattern_keys(uint8_t k, uint8_t m, bool is_held_key) {
             else
                 edit_buffer *= -1;
         }
-        else {
-            ss_set_pattern_val(&scene_state, pattern, base + offset, -v);
-        }
+        else { ss_set_pattern_val(&scene_state, pattern, base + offset, -v); }
         dirty = true;
     }
     // <space>: toggle non-zero to zero, and zero to 1

--- a/src/ops/hardware.c
+++ b/src/ops/hardware.c
@@ -370,9 +370,7 @@ static void op_TR_POL_set(const void *NOTUSED(data), scene_state_t *ss,
     a--;
     if (a < 0)
         return;
-    else if (a < 4) {
-        ss->variables.tr_pol[a] = b > 0;
-    }
+    else if (a < 4) { ss->variables.tr_pol[a] = b > 0; }
     else if (a < 20) {
         uint8_t d[] = { II_ANSIBLE_TR_POL, a & 0x3, b > 0 };
         uint8_t addr = II_ANSIBLE_ADDR + (((a - 4) >> 2) << 1);
@@ -494,9 +492,7 @@ static void op_MUTE_get(const void *NOTUSED(data), scene_state_t *ss,
                         exec_state_t *NOTUSED(es), command_state_t *cs) {
     int16_t a = cs_pop(cs) - 1;
     if (a >= 0 && a < TRIGGER_INPUTS) { cs_push(cs, ss_get_mute(ss, a)); }
-    else {
-        cs_push(cs, 0);
-    }
+    else { cs_push(cs, 0); }
 }
 
 static void op_MUTE_set(const void *NOTUSED(data), scene_state_t *ss,

--- a/src/ops/justfriends.c
+++ b/src/ops/justfriends.c
@@ -127,9 +127,7 @@ static void mod_JF2_func(scene_state_t *ss, exec_state_t *es,
 static void op_JF_SEL_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
                           exec_state_t *NOTUSED(es), command_state_t *cs) {
     if (cs_pop(cs) == 2) { unit = JF_ADDR_2; }
-    else {
-        unit = JF_ADDR;
-    }
+    else { unit = JF_ADDR; }
 }
 
 static void op_JF_TR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
@@ -145,9 +143,7 @@ static void op_JF_TR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
         a = a - 6;
         uint8_t d[] = { JF_TR, a, b };
         if (unit == JF_ADDR) { tele_ii_tx(JF_ADDR_2, d, 3); }
-        else {
-            tele_ii_tx(JF_ADDR, d, 3);
-        }
+        else { tele_ii_tx(JF_ADDR, d, 3); }
     }
     else {
         uint8_t d[] = { JF_TR, a, b };
@@ -191,9 +187,7 @@ static void op_JF_VTR_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
         a = a - 6;
         uint8_t d[] = { JF_VTR, a, b >> 8, b & 0xff };
         if (unit == JF_ADDR) { tele_ii_tx(JF_ADDR_2, d, 4); }
-        else {
-            tele_ii_tx(JF_ADDR, d, 4);
-        }
+        else { tele_ii_tx(JF_ADDR, d, 4); }
     }
     else {
         uint8_t d[] = { JF_VTR, a, b >> 8, b & 0xff };
@@ -231,9 +225,7 @@ static void op_JF_VOX_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
         a = a - 6;
         uint8_t d[] = { JF_VOX, a, b >> 8, b & 0xff, c >> 8, c & 0xff };
         if (unit == JF_ADDR) { tele_ii_tx(JF_ADDR_2, d, 6); }
-        else {
-            tele_ii_tx(JF_ADDR, d, 6);
-        }
+        else { tele_ii_tx(JF_ADDR, d, 6); }
     }
     else {
         uint8_t d[] = { JF_VOX, a, b >> 8, b & 0xff, c >> 8, c & 0xff };
@@ -262,9 +254,7 @@ static void op_JF_POLY_get(const void *NOTUSED(data),
     }
     else {
         if (unit == JF_ADDR) { tele_ii_tx(JF_ADDR_2, d, 5); }
-        else {
-            tele_ii_tx(JF_ADDR, d, 5);
-        }
+        else { tele_ii_tx(JF_ADDR, d, 5); }
         note_count++;
         if (note_count > 12) { note_count = 1; }
     }
@@ -299,9 +289,7 @@ static void op_JF_TUNE_get(const void *NOTUSED(data),
         a = a - 6;
         uint8_t d[] = { JF_TUNE, a, b, c };
         if (unit == JF_ADDR) { tele_ii_tx(JF_ADDR_2, d, 4); }
-        else {
-            tele_ii_tx(JF_ADDR, d, 4);
-        }
+        else { tele_ii_tx(JF_ADDR, d, 4); }
     }
     else {
         uint8_t d[] = { JF_TUNE, a, b, c };
@@ -338,9 +326,7 @@ static void op_JF_PITCH_get(const void *NOTUSED(data),
         a = a - 6;
         uint8_t d[] = { JF_PITCH, a, b >> 8, b & 0xff };
         if (unit == JF_ADDR) { tele_ii_tx(JF_ADDR_2, d, 6); }
-        else {
-            tele_ii_tx(JF_ADDR, d, 6);
-        }
+        else { tele_ii_tx(JF_ADDR, d, 6); }
     }
     else {
         uint8_t d[] = { JF_PITCH, a, b >> 8, b & 0xff };

--- a/src/ops/maths.c
+++ b/src/ops/maths.c
@@ -317,9 +317,7 @@ static int16_t volts_to_note_number(int16_t v_in) {
                 if ((target - table_n[mid - 1]) >= (table_n[mid] - target)) {
                     return (v_in < 0) ? -mid : mid;
                 }
-                else {
-                    return (v_in < 0) ? -(mid - 1) : mid - 1;
-                }
+                else { return (v_in < 0) ? -(mid - 1) : mid - 1; }
             }
             j = mid;
         }
@@ -328,9 +326,7 @@ static int16_t volts_to_note_number(int16_t v_in) {
                 if ((target - table_n[mid]) >= (table_n[mid + 1] - target)) {
                     return (v_in < 0) ? -(mid + 1) : mid + 1;
                 }
-                else {
-                    return (v_in < 0) ? -mid : mid;
-                }
+                else { return (v_in < 0) ? -mid : mid; }
             }
             i = mid + 1;
         }
@@ -410,9 +406,7 @@ static int16_t get_degree_in_bitmask_scale(int16_t scale_bits,
     }
     note = note + transpose;
     if (note > 0) { return table_n[note]; }
-    else {
-        return -table_n[-note];
-    }
+    else { return -table_n[-note]; }
 }
 
 static int16_t quantize_to_bitmask_scale(int16_t scale_bits, int16_t transpose,
@@ -1049,9 +1043,7 @@ static void op_HZ_get(const void *NOTUSED(data), scene_state_t *NOTUSED(ss),
             hz = table_hzv[note] +
                  (table_hzv[note + 1] - table_hzv[note]) * interpolate;
         }
-        else {
-            hz = table_hzv[note];
-        }
+        else { hz = table_hzv[note]; }
     }
 
     // return hz;
@@ -1182,13 +1174,9 @@ static void op_N_B_set(const void *NOTUSED(data), scene_state_t *ss,
         if (scale_bits > -nb_nbx_scale_presets) {
             scale_bits = bit_reverse(table_n_b[-scale_bits], 12);
         }
-        else {
-            scale_bits = bit_reverse(table_n_b[0], 12);
-        }
+        else { scale_bits = bit_reverse(table_n_b[0], 12); }
     }
-    else {
-        scale_bits = scale_bits & 0b111111111111;
-    }
+    else { scale_bits = scale_bits & 0b111111111111; }
 
     ss->variables.n_scale_bits[0] = scale_bits;
 }
@@ -1221,13 +1209,9 @@ static void op_N_BX_set(const void *NOTUSED(data), scene_state_t *ss,
         if (scale_bits > -nb_nbx_scale_presets) {
             scale_bits = bit_reverse(table_n_b[-scale_bits], 12);
         }
-        else {
-            scale_bits = bit_reverse(table_n_b[0], 12);
-        }
+        else { scale_bits = bit_reverse(table_n_b[0], 12); }
     }
-    else {
-        scale_bits = scale_bits & 0b111111111111;
-    }
+    else { scale_bits = scale_bits & 0b111111111111; }
 
     ss->variables.n_scale_bits[scale_nb] = scale_bits;
 }

--- a/src/ops/queue.c
+++ b/src/ops/queue.c
@@ -115,10 +115,12 @@ const tele_op_t op_Q_DIV =
 const tele_op_t op_Q_MOD =
     MAKE_GET_SET_OP(Q.MOD, op_Q_MOD_get, op_Q_MOD_set, 1, false);
 const tele_op_t op_Q_I = MAKE_GET_SET_OP(Q.I, op_Q_I_get, op_Q_I_set, 1, true);
+// clang-format off
 const tele_op_t op_Q_2P =
-    MAKE_GET_SET_OP(Q.2P,  op_Q_2P_get,  op_Q_2P_set, 0, false);
+    MAKE_GET_SET_OP(Q.2P, op_Q_2P_get, op_Q_2P_set, 0, false);
+// clang-format on
 const tele_op_t op_Q_P2 =
-    MAKE_GET_SET_OP(Q.P2,  op_Q_P2_get,  op_Q_P2_set, 0, false);
+    MAKE_GET_SET_OP(Q.P2, op_Q_P2_get, op_Q_P2_set, 0, false);
 
 static void op_Q_get(const void *NOTUSED(data), scene_state_t *ss,
                      exec_state_t *NOTUSED(es), command_state_t *cs) {
@@ -383,9 +385,7 @@ static void op_Q_SH_set(const void *NOTUSED(data), scene_state_t *ss,
     int16_t nb_shifts = cs_pop(cs);
     int16_t tmp[q_n];
     if (nb_shifts > 0) { nb_shifts = nb_shifts % q_n; }
-    else if (nb_shifts < 0) {
-        nb_shifts = q_n - (-nb_shifts % q_n);
-    }
+    else if (nb_shifts < 0) { nb_shifts = q_n - (-nb_shifts % q_n); }
 
     if (!nb_shifts) { return; }
 

--- a/src/scene_serialization.c
+++ b/src/scene_serialization.c
@@ -169,9 +169,7 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
             prev_cr = 0;
             continue;
         }
-        else {
-            prev_cr = 0;
-        }
+        else { prev_cr = 0; }
 
         if (c == '#' && new_line) {
             s = STATE_POUND;
@@ -202,9 +200,7 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
                 script = INIT_SCRIPT;
                 s2 = STATE_SCRIPT;
             }
-            else if (c == 'P') {
-                s2 = STATE_PATTERNS;
-            }
+            else if (c == 'P') { s2 = STATE_PATTERNS; }
             else if (c == 'G') {
                 grid_state = grid_num = grid_count = 0;
                 s2 = STATE_GRID;
@@ -214,9 +210,7 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
                 if (script < 0 || script >= EDITABLE_SCRIPT_COUNT) {
                     script = NO_SCRIPT;
                 }
-                else {
-                    s2 = STATE_SCRIPT;
-                }
+                else { s2 = STATE_SCRIPT; }
             }
 
             l = 0;
@@ -293,18 +287,10 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
                         // stream->print_dbg(" ");
                         // stream->print_dbg_ulong(num);
                     }
-                    else if (l == 0) {
-                        ss_set_pattern_len(scene, b, num);
-                    }
-                    else if (l == 1) {
-                        ss_set_pattern_wrap(scene, b, num);
-                    }
-                    else if (l == 2) {
-                        ss_set_pattern_start(scene, b, num);
-                    }
-                    else if (l == 3) {
-                        ss_set_pattern_end(scene, b, num);
-                    }
+                    else if (l == 0) { ss_set_pattern_len(scene, b, num); }
+                    else if (l == 1) { ss_set_pattern_wrap(scene, b, num); }
+                    else if (l == 2) { ss_set_pattern_start(scene, b, num); }
+                    else if (l == 3) { ss_set_pattern_end(scene, b, num); }
                 }
 
                 b++;

--- a/tests/log.c
+++ b/tests/log.c
@@ -1,10 +1,10 @@
+#include "log.h"
+
 #include <stdarg.h>
 #include <stdbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
-
-#include "log.h"
 
 static inline log_t *get_log() {
     static log_t log;

--- a/tests/log.h
+++ b/tests/log.h
@@ -1,3 +1,6 @@
+
+#include <stddef.h>
+
 #ifndef _LOG_H
 #define _LOG_H
 

--- a/tests/main.c
+++ b/tests/main.c
@@ -1,5 +1,6 @@
 #include <stdint.h>
 
+#include "drum_helpers_tests.h"
 #include "greatest/greatest.h"
 #include "match_token_tests.h"
 #include "op_mod_tests.h"
@@ -9,7 +10,6 @@
 #include "teletype.h"
 #include "teletype_io.h"
 #include "turtle_tests.h"
-#include "drum_helpers_tests.h"
 
 uint32_t tele_get_ticks() {
     return 0;

--- a/tests/match_token_tests.c
+++ b/tests/match_token_tests.c
@@ -3,7 +3,6 @@
 #include <string.h>
 
 #include "greatest/greatest.h"
-
 #include "match_token.h"
 #include "ops/op.h"
 #include "ops/op_enum.h"

--- a/tests/op_mod_tests.c
+++ b/tests/op_mod_tests.c
@@ -1,7 +1,6 @@
 #include "op_mod_tests.h"
 
 #include "greatest/greatest.h"
-
 #include "ops/op.h"
 #include "teletype.h"
 
@@ -57,9 +56,7 @@ TEST op_stack_size() {
             if (op->returns) {
                 ASSERT_EQm(op->name, cs_stack_size(&cs), stack_extra + 1);
             }
-            else {
-                ASSERT_EQm(op->name, cs_stack_size(&cs), stack_extra);
-            }
+            else { ASSERT_EQm(op->name, cs_stack_size(&cs), stack_extra); }
         }
 
         if (op->set != NULL) {
@@ -111,10 +108,10 @@ TEST mod_stack_size() {
         for (int j = 0; j < mod->params + stack_extra; j++) cs_push(&cs, 0);
 
         // execute func
-        const tele_command_t sub_command = {.length = 1,
-                                            .separator = 0,
-                                            .data = { {.tag = OP,
-                                                       .value = E_OP_A } } };
+        const tele_command_t sub_command = { .length = 1,
+                                             .separator = 0,
+                                             .data = { { .tag = OP,
+                                                         .value = E_OP_A } } };
         mod->func(&ss, &es, &cs, &sub_command);
 
         // check that the stack has the correct number of items in it

--- a/tests/parser_tests.c
+++ b/tests/parser_tests.c
@@ -1,7 +1,6 @@
 #include "parser_tests.h"
 
 #include "greatest/greatest.h"
-
 #include "ops/op.h"
 #include "ops/op_enum.h"
 #include "teletype.h"

--- a/tests/process_tests.c
+++ b/tests/process_tests.c
@@ -5,13 +5,12 @@
 #include <unistd.h>  // ssize_t
 
 #include "greatest/greatest.h"
-
 #include "teletype.h"
 // runs multiple lines of commands and then asserts that the final answer is
 // correct (allows contiuation of state)
 TEST process_helper_state(scene_state_t* ss, size_t n, char* lines[],
                           int16_t answer) {
-    process_result_t result = {.has_value = false, .value = 0 };
+    process_result_t result = { .has_value = false, .value = 0 };
     exec_state_t es;
     es_init(&es);
     es_push(&es);
@@ -308,7 +307,7 @@ TEST test_P_ROT_1() {
     scene_state_t ss;
     ss_init(&ss);
 
-    char* prep1[3] = { "P.START 0", "P.END 3", "0"};
+    char* prep1[3] = { "P.START 0", "P.END 3", "0" };
     CHECK_CALL(process_helper_state(&ss, 3, prep1, 0));
 
     char* prep2[5] = { "P 0 1", "P 1 2", "P 2 3", "P 3 4", "P P.END" };
@@ -336,7 +335,7 @@ TEST test_P_ROT_3() {
     scene_state_t ss;
     ss_init(&ss);
 
-    char* prep1[3] = { "P.START 0", "P.END 3", "0"};
+    char* prep1[3] = { "P.START 0", "P.END 3", "0" };
     CHECK_CALL(process_helper_state(&ss, 3, prep1, 0));
 
     char* prep2[5] = { "P 0 1", "P 1 2", "P 2 3", "P 3 4", "P P.END" };

--- a/tests/turtle_tests.c
+++ b/tests/turtle_tests.c
@@ -1,10 +1,10 @@
 #include "turtle_tests.h"
+
 #include <stdlib.h>
 #include <string.h>
 #include <unistd.h>  // ssize_t
 
 #include "greatest/greatest.h"
-
 #include "log.h"
 #include "teletype.h"
 
@@ -34,7 +34,7 @@ static const char *error_message(error_t e) {
 TEST process_helper_state(scene_state_t *ss, size_t n, char *lines[],
                           int16_t answer) {
     count++;
-    process_result_t result = {.has_value = false, .value = 0 };
+    process_result_t result = { .has_value = false, .value = 0 };
     exec_state_t es;
     memset(&es, 0, sizeof(es));
     es_init(&es);


### PR DESCRIPTION
#### What does this PR do?
Adds clang-format to the Actions workflow on pull requests.

This also removes the "did you run tests?" and "did you run make format?" manual questions in the template, since they're presumably now redundant with the automated status checks.

If clang-format finds formatting issues, the status check will fail, and the suggested changes will be shown in the Actions log in diff format, for example:
```
--- module/flash.c	(original)
+++ module/flash.c	(reformatted)
@@ -57,10 +57,8 @@
         while (confirm == 1 && (++counter < TIMEOUT)) {
             confirm = gpio_get_pin_value(NMI);
             if ((counter % 1000) == 0) {
-                if (++toggle % 2)
-                    gpio_set_pin_low(B11);
-                else
-                    gpio_set_pin_high(B11);
+                if (++toggle % 2) gpio_set_pin_low(B11);
+                else gpio_set_pin_high(B11);
             }
             print_dbg_ulong(confirm);
         }
```

#### How should this be manually tested?

Example failing and succeeding checks:
https://github.com/Dewb/teletype/pull/5

#### Any background context you want to provide?

This will use the latest clang-format installed on the GitHub actions runner, which I believe is 13. We noticed some odd behavior where different versions of clang-format would produce different outputs. I noticed that in our `.clang-format`, the option `AllowShortBlocksOnASingleLine` was set to `true`, but this is an enum option not a boolean. I'm not sure if that was the source of the unspecified behavior, but clang-format 13 and 14 produce the same output now. Not sure about 12.

#### I have,
* (n/a) updated `CHANGELOG.md` and `whats_new.md`
* (n/a) updated the documentation
* (n/a) updated `help_mode.c` (if applicable)

