### PR TITLE
Usb minimal menu

### DIFF
--- a/module/globals.h
+++ b/module/globals.h
@@ -40,6 +40,8 @@ void set_mode(tele_mode_t mode);
 void set_last_mode(void);
 void clear_delays_and_slews(scene_state_t *ss);
 
+void assign_main_event_handlers(void);
+
 // global copy buffer
 extern char copy_buffer[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
 extern uint8_t copy_buffer_len;

--- a/module/main.c
+++ b/module/main.c
@@ -171,7 +171,7 @@ static void handler_AppCustom(int32_t data);
 
 // event queue
 static void empty_event_handlers(void);
-static void assign_main_event_handlers(void);
+void assign_main_event_handlers(void);
 static void assign_msc_event_handlers(void);
 static void check_events(void);
 
@@ -475,22 +475,11 @@ void handler_MscConnect(int32_t data) {
     // disable event handlers while doing USB write
     assign_msc_event_handlers();
 
-    // disable timers
-    u8 flags = irqs_pause();
-
     // clear screen
     for (size_t i = 0; i < 8; i++) {
         region_fill(&line[i], 0);
         region_draw(&line[i]);
     }
-
-    // do USB
-    tele_usb_disk();
-
-    // renable teletype
-    set_mode(M_LIVE);
-    assign_main_event_handlers();
-    irqs_resume(flags);
 }
 
 void handler_Trigger(int32_t data) {
@@ -748,6 +737,7 @@ static void assign_msc_event_handlers(void) {
 
     app_event_handlers[kEventFront] = &handler_usb_Front;
     app_event_handlers[kEventPollADC] = &handler_usb_PollADC;
+    app_event_handlers[kEventScreenRefresh] = &handler_usb_ScreenRefresh;
 }
 
 // app event loop

--- a/module/main.c
+++ b/module/main.c
@@ -746,8 +746,8 @@ void assign_main_event_handlers() {
 static void assign_msc_event_handlers(void) {
     empty_event_handlers();
 
-    // one day this could be used to map the front button and pot to be used as
-    // a UI with a memory stick
+    app_event_handlers[kEventFront] = &handler_usb_Front;
+    app_event_handlers[kEventPollADC] = &handler_usb_PollADC;
 }
 
 // app event loop

--- a/module/usb_disk_mode.c
+++ b/module/usb_disk_mode.c
@@ -9,6 +9,7 @@
 #include "scene_serialization.h"
 
 // libavr32
+#include "adc.h"
 #include "font.h"
 #include "region.h"
 #include "util.h"
@@ -24,7 +25,14 @@
 #include "uhi_msc_mem.h"
 #include "usb_protocol_msc.h"
 
-// Local functions for usb filesystem serialization
+// Local declarations
+void draw_usb_menu(void);
+void draw_usb_menu_item(uint8_t item_num, const char* text);
+bool tele_usb_disk_write_operation(uint8_t* plun_state, uint8_t* plun);
+void tele_usb_disk_read_operation(void);
+
+
+// Local functions to implement the usb filesystem serialization contract
 void tele_usb_putc(void* self_data, uint8_t c);
 void tele_usb_write_buf(void* self_data, uint8_t* buffer, uint16_t size);
 uint16_t tele_usb_getc(void* self_data);
@@ -46,11 +54,62 @@ bool tele_usb_eof(void* self_data) {
     return file_eof() != 0;
 }
 
+// *very* basic USB operations menu
+
+
+typedef enum {
+    USB_MENU_COMMAND_WRITE = 0,
+    USB_MENU_COMMAND_READ = 1,
+    USB_MENU_COMMAND_BOTH = 2,
+    USB_MENU_COMMAND_EXIT = 3,
+} usb_menu_command_t;
+
+usb_menu_command_t usb_menu_command;
+bool usb_menu_waiting;
+
+
+void draw_usb_menu(void) {
+    draw_usb_menu_item(0, "WRITE TO USB");
+    draw_usb_menu_item(1, "READ FROM USB");
+    draw_usb_menu_item(2, "DO BOTH");
+    draw_usb_menu_item(3, "EXIT");
+}
+
+void draw_usb_menu_item(uint8_t item_num, const char* text) {
+    uint8_t line_num = 2 + item_num;
+    uint8_t fg = usb_menu_command == item_num ? 0 : 0xa;
+    uint8_t bg = usb_menu_command == item_num ? 0xa : 0;
+    region_fill(&line[line_num], 0);
+    font_string_region_clip_tab(&line[line_num], text, 2, 0, fg, bg);
+    region_draw(&line[line_num]);
+}
+
+void handler_usb_PollADC(int32_t data) {
+    uint16_t adc[4];
+    adc_convert(&adc);
+    uint8_t cursor = adc[1] >> 9;
+    uint8_t deadzone = cursor & 1;
+    cursor >>= 1;
+    if (!deadzone || abs(cursor - usb_menu_command) > 1) {
+        usb_menu_command = cursor;
+        draw_usb_menu();
+    }
+}
+
+void handler_usb_Front(int32_t data) {
+    if (data != 0) { usb_menu_waiting = false; }
+}
+
 // usb disk mode entry point
 void tele_usb_disk() {
-    char text_buffer[40];
-    print_dbg("\r\nusb");
+    usb_menu_command = USB_MENU_COMMAND_EXIT;
+    usb_menu_waiting = true;
+    draw_usb_menu();
 
+    while (usb_menu_waiting) {}
+    if (usb_menu_command == USB_MENU_COMMAND_EXIT) { return; }
+
+    print_dbg("\r\nusb");
     uint8_t lun_state = 0;
 
     for (uint8_t lun = 0; (lun < uhi_msc_mem_get_lun()) && (lun < 8); lun++) {
@@ -73,128 +132,146 @@ void tele_usb_disk() {
         // Check if LUN has been already tested
         if (lun_state & (1 << lun)) { continue; }
 
-        // WRITE SCENES
-        char filename[13];
-        strcpy(filename, "tt00s.txt");
+        if (usb_menu_command == USB_MENU_COMMAND_WRITE ||
+            usb_menu_command == USB_MENU_COMMAND_BOTH) {
+            if (!tele_usb_disk_write_operation(&lun_state, &lun)) { continue; }
+        }
+        if (usb_menu_command == USB_MENU_COMMAND_READ ||
+            usb_menu_command == USB_MENU_COMMAND_BOTH) {
+            tele_usb_disk_read_operation();
+        }
 
-        print_dbg("\r\nwriting scenes");
-        strcpy(text_buffer, "WRITE");
+        nav_exit();
+    }
+}
+
+bool tele_usb_disk_write_operation(uint8_t* plun_state, uint8_t* plun) {
+    // WRITE SCENES
+    print_dbg("\r\nwriting scenes");
+
+    char filename[13];
+    strcpy(filename, "tt00s.txt");
+
+    char text_buffer[40];
+    strcpy(text_buffer, "WRITE");
+    region_fill(&line[0], 0);
+    font_string_region_clip_tab(&line[0], text_buffer, 2, 0, 0xa, 0);
+    region_draw(&line[0]);
+
+    for (int i = 0; i < SCENE_SLOTS; i++) {
+        scene_state_t scene;
+        ss_init(&scene);
+
+        char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
+        memset(text, 0, SCENE_TEXT_LINES * SCENE_TEXT_CHARS);
+
+        strcat(text_buffer, ".");  // strcat is dangerous, make sure the
+                                   // buffer is large enough!
         region_fill(&line[0], 0);
         font_string_region_clip_tab(&line[0], text_buffer, 2, 0, 0xa, 0);
         region_draw(&line[0]);
 
-        for (int i = 0; i < SCENE_SLOTS; i++) {
-            scene_state_t scene;
-            ss_init(&scene);
+        flash_read(i, &scene, &text, 1, 1, 1);
 
-            char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
-            memset(text, 0, SCENE_TEXT_LINES * SCENE_TEXT_CHARS);
-
-            strcat(text_buffer, ".");  // strcat is dangerous, make sure the
-                                       // buffer is large enough!
-            region_fill(&line[0], 0);
-            font_string_region_clip_tab(&line[0], text_buffer, 2, 0, 0xa, 0);
-            region_draw(&line[0]);
-
-            flash_read(i, &scene, &text, 1, 1, 1);
-
-            if (!nav_file_create((FS_STRING)filename)) {
-                if (fs_g_status != FS_ERR_FILE_EXIST) {
-                    if (fs_g_status == FS_LUN_WP) {
-                        // Test can be done only on no write protected
-                        // device
-                        continue;
-                    }
-                    lun_state |= (1 << lun);  // LUN test is done.
-                    print_dbg("\r\nfail");
-                    continue;
-                }
-            }
-
-            if (!file_open(FOPEN_MODE_W)) {
+        if (!nav_file_create((FS_STRING)filename)) {
+            if (fs_g_status != FS_ERR_FILE_EXIST) {
                 if (fs_g_status == FS_LUN_WP) {
                     // Test can be done only on no write protected
                     // device
-                    continue;
+                    return false;
                 }
-                lun_state |= (1 << lun);  // LUN test is done.
+                *plun_state |= (1 << *plun);  // LUN test is done.
                 print_dbg("\r\nfail");
-                continue;
+                return false;
             }
+        }
 
-            tt_serializer_t tele_usb_writer;
-            tele_usb_writer.write_char = &tele_usb_putc;
-            tele_usb_writer.write_buffer = &tele_usb_write_buf;
-            tele_usb_writer.print_dbg = &print_dbg;
-            tele_usb_writer.data =
-                NULL;  // asf disk i/o holds state, no handles needed
-            serialize_scene(&tele_usb_writer, &scene, &text);
-
-            file_close();
-            lun_state |= (1 << lun);  // LUN test is done.
-
-            if (filename[3] == '9') {
-                filename[3] = '0';
-                filename[2]++;
+        if (!file_open(FOPEN_MODE_W)) {
+            if (fs_g_status == FS_LUN_WP) {
+                // Test can be done only on no write protected
+                // device
+                return false;
             }
-            else
-                filename[3]++;
+            *plun_state |= (1 << *plun);  // LUN test is done.
+            print_dbg("\r\nfail");
+            return false;
+        }
 
-            print_dbg(".");
+        tt_serializer_t tele_usb_writer;
+        tele_usb_writer.write_char = &tele_usb_putc;
+        tele_usb_writer.write_buffer = &tele_usb_write_buf;
+        tele_usb_writer.print_dbg = &print_dbg;
+        tele_usb_writer.data =
+            NULL;  // asf disk i/o holds state, no handles needed
+        serialize_scene(&tele_usb_writer, &scene, &text);
+
+        file_close();
+        *plun_state |= (1 << *plun);  // LUN test is done.
+
+        if (filename[3] == '9') {
+            filename[3] = '0';
+            filename[2]++;
+        }
+        else
+            filename[3]++;
+
+        print_dbg(".");
+    }
+
+    nav_filelist_reset();
+    return true;
+}
+
+void tele_usb_disk_read_operation() {
+    // READ SCENES
+    print_dbg("\r\nreading scenes...");
+
+    char filename[13];
+    strcpy(filename, "tt00.txt");
+
+    char text_buffer[40];
+    strcpy(text_buffer, "READ");
+    region_fill(&line[1], 0);
+    font_string_region_clip_tab(&line[1], text_buffer, 2, 0, 0xa, 0);
+    region_draw(&line[1]);
+
+    for (int i = 0; i < SCENE_SLOTS; i++) {
+        scene_state_t scene;
+        ss_init(&scene);
+        char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
+        memset(text, 0, SCENE_TEXT_LINES * SCENE_TEXT_CHARS);
+
+        strcat(text_buffer, ".");  // strcat is dangerous, make sure the
+                                   // buffer is large enough!
+        region_fill(&line[1], 0);
+        font_string_region_clip_tab(&line[1], text_buffer, 2, 0, 0xa, 0);
+        region_draw(&line[1]);
+        if (nav_filelist_findname(filename, 0)) {
+            print_dbg("\r\nfound: ");
+            print_dbg(filename);
+            if (!file_open(FOPEN_MODE_R))
+                print_dbg("\r\ncan't open");
+            else {
+                tt_deserializer_t tele_usb_reader;
+                tele_usb_reader.read_char = &tele_usb_getc;
+                tele_usb_reader.eof = &tele_usb_eof;
+                tele_usb_reader.print_dbg = &print_dbg;
+                tele_usb_reader.data =
+                    NULL;  // asf disk i/o holds state, no handles needed
+                deserialize_scene(&tele_usb_reader, &scene, &text);
+
+                file_close();
+                flash_write(i, &scene, &text);
+            }
         }
 
         nav_filelist_reset();
 
-
-        // READ SCENES
-        strcpy(filename, "tt00.txt");
-        print_dbg("\r\nreading scenes...");
-
-        strcpy(text_buffer, "READ");
-        region_fill(&line[1], 0);
-        font_string_region_clip_tab(&line[1], text_buffer, 2, 0, 0xa, 0);
-        region_draw(&line[1]);
-
-        for (int i = 0; i < SCENE_SLOTS; i++) {
-            scene_state_t scene;
-            ss_init(&scene);
-            char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
-            memset(text, 0, SCENE_TEXT_LINES * SCENE_TEXT_CHARS);
-
-            strcat(text_buffer, ".");  // strcat is dangerous, make sure the
-                                       // buffer is large enough!
-            region_fill(&line[1], 0);
-            font_string_region_clip_tab(&line[1], text_buffer, 2, 0, 0xa, 0);
-            region_draw(&line[1]);
-            if (nav_filelist_findname(filename, 0)) {
-                print_dbg("\r\nfound: ");
-                print_dbg(filename);
-                if (!file_open(FOPEN_MODE_R))
-                    print_dbg("\r\ncan't open");
-                else {
-                    tt_deserializer_t tele_usb_reader;
-                    tele_usb_reader.read_char = &tele_usb_getc;
-                    tele_usb_reader.eof = &tele_usb_eof;
-                    tele_usb_reader.print_dbg = &print_dbg;
-                    tele_usb_reader.data =
-                        NULL;  // asf disk i/o holds state, no handles needed
-                    deserialize_scene(&tele_usb_reader, &scene, &text);
-
-                    file_close();
-                    flash_write(i, &scene, &text);
-                }
-            }
-
-            nav_filelist_reset();
-
-            if (filename[3] == '9') {
-                filename[3] = '0';
-                filename[2]++;
-            }
-            else
-                filename[3]++;
+        if (filename[3] == '9') {
+            filename[3] = '0';
+            filename[2]++;
         }
+        else
+            filename[3]++;
     }
-
-    nav_exit();
 }

--- a/module/usb_disk_mode.h
+++ b/module/usb_disk_mode.h
@@ -5,6 +5,7 @@
 
 void handler_usb_PollADC(int32_t data);
 void handler_usb_Front(int32_t data);
+void handler_usb_ScreenRefresh(int32_t data);
 
 void tele_usb_disk(void);
 

--- a/module/usb_disk_mode.h
+++ b/module/usb_disk_mode.h
@@ -1,6 +1,11 @@
 #ifndef _USB_DISK_MODE_H_
 #define _USB_DISK_MODE_H_
 
+#include <stdint.h>
+
+void handler_usb_PollADC(int32_t data);
+void handler_usb_Front(int32_t data);
+
 void tele_usb_disk(void);
 
 #endif


### PR DESCRIPTION
#### What does this PR do?

Adds a minimal menu for USB operations. This feature design was suggested by @beels as a minimal useful gesture towards his 
WIP [usb-disk-menu branch](https://github.com/beels/teletype/tree/feature/usb-disk-menu).

#### How should this be manually tested?

Insert a USB stick. You should see a menu with four options. Turn the param knob to highlight an option and press the front button to select it. `EXIT` will return to live mode without doing anything. `WRITE TO USB` will copy scenes from flash to the `tt00s.txt` files. `READ FROM USB` will copy the contents of the `tt00.txt` files to flash memory. `DO BOTH` will perform both a write and then a read, the previous behavior.

#### Any background context you want to provide?

From Discord discussion, there are a couple motivations here: 
* providing a failsafe to avoid inadvertent usb operations if an inserted USB drive is physically touched in such a way that it retriggers the MSC connection event.
* making a small gesture in this direction to reduce the activation energy for continuing to enhance the usb menu in future releases.

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* [ ] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
