### PR TITLE
Correctly document N.CS scales 7 & 8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -29,6 +29,7 @@
 - **NEW**: new op: `CV.GET`
 - **NEW**: basic menu for reading/writing scenes when a USB stick is inserted
 - **NEW**: new ops: `CV.CAL` and `CV.CAL.RESET` to calibrate CV outputs
+- **FIX**: in N.CS docs, correctly identify scales 7 (Locrian) and 8 (Mixolydian)
 
 ## v4.0.0
 

--- a/docs/ops/maths.toml
+++ b/docs/ops/maths.toml
@@ -458,7 +458,7 @@ Scales
  - `4` = Dorian
  - `5` = Phrygian
  - `6` = Lydian
- - `7` = Myxolidian
+ - `7` = Mixolydian
  - `8` = Locrian
 """
 
@@ -498,8 +498,8 @@ Chord Scales - Refer to chord indices in `N.C` OP
  - `4` = Dorian `{1, 1, 0, 2, 1, 6, 0}`
  - `5` = Phrygian `{1, 0, 2, 1, 6, 0, 1}`
  - `6` = Lydian `{0, 2, 1, 6, 0, 1, 1}`
- - `7` = Myxolidian `{6, 0, 1, 1, 0, 2, 1}`
- - `8` = Locrian `{6, 0, 1, 1, 0, 2, 1}`
+ - `7` = Locrian `{6, 0, 1, 1, 0, 2, 1}`
+ - `8` = Mixolydian `{2, 1, 6, 0, 1, 1, 0}`
  """
  
 [V]

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -27,6 +27,7 @@
 - **NEW**: new op: `CV.GET`
 - **NEW**: basic menu for reading/writing scenes when a USB stick is inserted
 - **NEW**: new ops: `CV.CAL` and `CV.CAL.RESET` to calibrate CV outputs
+- **FIX**: in N.CS docs, correctly identify scales 7 (Locrian) and 8 (Mixolydian)
 
 ## v4.0.0
 


### PR DESCRIPTION
#### What does this PR do?

Adjusts the documentation for the N.CS scales to match the implementation in [table.c](https://github.com/monome/teletype/blob/7041e67742a84e93c4f0d2797348e00d5a76dd99/src/table.c#L135)

#### Provide links to any related discussion on [lines](https://llllllll.co/).

N.CS introduced here: https://llllllll.co/t/teletype-firmware-discussion/13961/49

#### How should this be manually tested?

Compare the documentation to the results of the N.CS op on scales 7 and 8.

#### Any background context you want to provide?

I noticed the issue when I was comparing the N.CS implementation to the similar norns functionality in https://github.com/monome/norns/pull/1688.

#### If the related Github issues aren't referenced in your commits, please link to them here.

(n/a)

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [x] updated the documentation
* [x] updated `help_mode.c` (if applicable)
