### PR TITLE
Update libavr32 for cdc size fix

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -30,6 +30,7 @@
 - **NEW**: basic menu for reading/writing scenes when a USB stick is inserted
 - **NEW**: new ops: `CV.CAL` and `CV.CAL.RESET` to calibrate CV outputs
 - **FIX**: N.CS scales 7 & 8 were incorrectly swapped; make them consistent with N.S and docs
+- **FIX**: libavr32 update: support CDC grid size detection (e.g. zero), increase HID message buffer
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -28,6 +28,7 @@
 - **NEW**: basic menu for reading/writing scenes when a USB stick is inserted
 - **NEW**: new ops: `CV.CAL` and `CV.CAL.RESET` to calibrate CV outputs
 - **FIX**: N.CS scales 7 & 8 were incorrectly swapped; make them consistent with N.S and docs
+- **FIX**: libavr32 update: support CDC grid size detection (e.g. zero), increase HID message buffer
 
 ## v4.0.0
 

--- a/module/main.c
+++ b/module/main.c
@@ -984,11 +984,13 @@ static void setup_midi(void) {
     midi_behavior.channel_pressure = NULL;
     midi_behavior.pitch_bend = NULL;
     midi_behavior.control_change = &midi_control_change;
+    midi_behavior.program_change = NULL;
     midi_behavior.clock_tick = &midi_clock_tick;
     midi_behavior.seq_start = &midi_seq_start;
     midi_behavior.seq_stop = &midi_seq_stop;
     midi_behavior.seq_continue = &midi_seq_continue;
     midi_behavior.panic = NULL;
+    midi_behavior.aftertouch = NULL;
 }
 
 


### PR DESCRIPTION
#### What does this PR do?

Updates libavr32 submodule to head.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

n/a

#### How should this be manually tested?

try a zero, make sure HID still works, make sure USB MIDI aftertouch doesn't crash

#### Any background context you want to provide?

the motivating change here is the CDC size fix, everything else in the update is just ansible/etc fixes coming along for the ride, but it all seems safe. major change is new midi event handlers. json and timer changes should not affect teletype.

#### If the related Github issues aren't referenced in your commits, please link to them here.

n/a

#### I have,
* [X] updated `CHANGELOG.md` and `whats_new.md`
* n/a updated the documentation
* n/a updated `help_mode.c` (if applicable)
