### PR TITLE
Bring x64/ARM build compatibility patches into main

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@
 - **NEW**: new ops: `CV.CAL` and `CV.CAL.RESET` to calibrate CV outputs
 - **FIX**: N.CS scales 7 & 8 were incorrectly swapped; make them consistent with N.S and docs
 - **FIX**: libavr32 update: support CDC grid size detection (e.g. zero), increase HID message buffer
+- **NEW**: apply VCV Rack compatibility patches, so branches off main can be used in both hardware and software
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -29,6 +29,7 @@
 - **NEW**: new ops: `CV.CAL` and `CV.CAL.RESET` to calibrate CV outputs
 - **FIX**: N.CS scales 7 & 8 were incorrectly swapped; make them consistent with N.S and docs
 - **FIX**: libavr32 update: support CDC grid size detection (e.g. zero), increase HID message buffer
+- **NEW**: apply VCV Rack compatibility patches, so branches off main can be used in both hardware and software
 
 ## v4.0.0
 

--- a/module/flash.c
+++ b/module/flash.c
@@ -12,33 +12,14 @@
 #include "teletype.h"
 
 #define FIRSTRUN_KEY 0x22
-#define BUTTON_STATE_SIZE (GRID_BUTTON_COUNT >> 3)
 
-typedef struct {
-    uint8_t button_states[BUTTON_STATE_SIZE];
-    uint8_t fader_states[GRID_FADER_COUNT];
-} grid_data_t;
 static grid_data_t grid_data;
 
-// NVRAM data structure located in the flash array.
-typedef const struct {
-    scene_script_t scripts[EDITABLE_SCRIPT_COUNT];
-    scene_pattern_t patterns[PATTERN_COUNT];
-    grid_data_t grid_data;
-    char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
-} nvram_scene_t;
-
-typedef const struct {
-    nvram_scene_t scenes[SCENE_SLOTS];
-    uint8_t last_scene;
-    tele_mode_t last_mode;
-    uint8_t fresh;
-    cal_data_t cal;
-    device_config_t device_config;
-} nvram_data_t;
-
-
+#if defined(__AVR32__)
 static __attribute__((__section__(".flash_nvram"))) nvram_data_t f;
+#else
+nvram_data_t f;
+#endif
 
 static void pack_grid(scene_state_t *scene);
 static void unpack_grid(scene_state_t *scene);

--- a/module/flash.h
+++ b/module/flash.h
@@ -10,23 +10,20 @@
 #define SCENE_SLOTS 32
 #define BUTTON_STATE_SIZE (GRID_BUTTON_COUNT >> 3)
 
-typedef struct
-{
+typedef struct {
     uint8_t button_states[BUTTON_STATE_SIZE];
     uint8_t fader_states[GRID_FADER_COUNT];
 } grid_data_t;
 
 // NVRAM data structure located in the flash array.
-typedef struct
-{
-    scene_script_t scripts[EDITABLE_SCRIPT_COUNT]; // Exclude TEMP script
+typedef struct {
+    scene_script_t scripts[EDITABLE_SCRIPT_COUNT];  // Exclude TEMP script
     scene_pattern_t patterns[PATTERN_COUNT];
     grid_data_t grid_data;
     char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
 } nvram_scene_t;
 
-typedef struct
-{
+typedef struct {
     nvram_scene_t scenes[SCENE_SLOTS];
     uint8_t last_scene;
     tele_mode_t last_mode;

--- a/module/flash.h
+++ b/module/flash.h
@@ -8,6 +8,32 @@
 #include "teletype.h"
 
 #define SCENE_SLOTS 32
+#define BUTTON_STATE_SIZE (GRID_BUTTON_COUNT >> 3)
+
+typedef struct
+{
+    uint8_t button_states[BUTTON_STATE_SIZE];
+    uint8_t fader_states[GRID_FADER_COUNT];
+} grid_data_t;
+
+// NVRAM data structure located in the flash array.
+typedef struct
+{
+    scene_script_t scripts[EDITABLE_SCRIPT_COUNT]; // Exclude TEMP script
+    scene_pattern_t patterns[PATTERN_COUNT];
+    grid_data_t grid_data;
+    char text[SCENE_TEXT_LINES][SCENE_TEXT_CHARS];
+} nvram_scene_t;
+
+typedef struct
+{
+    nvram_scene_t scenes[SCENE_SLOTS];
+    uint8_t last_scene;
+    tele_mode_t last_mode;
+    uint8_t fresh;
+    cal_data_t cal;
+    device_config_t device_config;
+} nvram_data_t;
 
 u8 is_flash_fresh(void);
 void flash_prepare(void);

--- a/module/main.c
+++ b/module/main.c
@@ -173,10 +173,10 @@ static void handler_AppCustom(int32_t data);
 static void empty_event_handlers(void);
 void assign_main_event_handlers(void);
 static void assign_msc_event_handlers(void);
-static void check_events(void);
+void check_events(void);
 
 // key handling
-static void process_keypress(uint8_t key, uint8_t mod_key, bool is_held_key,
+void process_keypress(uint8_t key, uint8_t mod_key, bool is_held_key,
                              bool is_release);
 static bool process_global_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
 
@@ -188,6 +188,8 @@ void timers_unset_monome(void);
 static void render_init(void);
 static void exit_screensaver(void);
 static void update_device_config(u8 refresh);
+
+void initialize_module(void);
 
 
 ////////////////////////////////////////////////////////////////////////////////
@@ -1184,7 +1186,7 @@ void reset_midi_counter() {
 ////////////////////////////////////////////////////////////////////////////////
 // main
 
-int main(void) {
+void initialize_module(void) {
     sysclk_init();
 
     init_dbg_rs232(FMCK_HZ);
@@ -1300,7 +1302,10 @@ int main(void) {
 
     run_script(&scene_state, INIT_SCRIPT);
     scene_state.initializing = false;
+}
 
+int main(void) {
+    initialize_module();
 #ifdef TELETYPE_PROFILE
     uint32_t count = 0;
 #endif

--- a/module/main.c
+++ b/module/main.c
@@ -177,7 +177,7 @@ void check_events(void);
 
 // key handling
 void process_keypress(uint8_t key, uint8_t mod_key, bool is_held_key,
-                             bool is_release);
+                      bool is_release);
 static bool process_global_keys(uint8_t key, uint8_t mod_key, bool is_held_key);
 
 // start/stop monome polling/refresh timers


### PR DESCRIPTION
#### What does this PR do?

This folds in changes necessary to build the TT source for x64/ARM and use it in VCV Rack. There is no direct hardware benefit to these changes, but they should be benign.

The indirect benefit to merging this is that afterwards any branch off main can be tested in VCV Rack prior to being tested in hardware, without having to first pollute the feature branch with Rack compatibility patches.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/monome-vcv-rack-ports-development-log/10337

#### How should this be manually tested?

Build, flash to module, test scene save and restore.

#### Any background context you want to provide?

n/a

#### If the related Github issues aren't referenced in your commits, please link to them here.

n/a

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* (n/a) updated the documentation
* (n/a) updated `help_mode.c` (if applicable)
