### PR TITLE
fixes for function params and grid serialization

### DIFF
--- a/src/ops/delay.c
+++ b/src/ops/delay.c
@@ -56,6 +56,8 @@ static bool delay_common_add(scene_state_t *ss, exec_state_t *es,
         ss->delay.time[i] = delay_time;
         ss->delay.origin_script[i] = es_variables(es)->script_number;
         ss->delay.origin_i[i] = es_variables(es)->i;
+        ss->delay.origin_fparam1[i] = es_variables(es)->fparam1;
+        ss->delay.origin_fparam2[i] = es_variables(es)->fparam2;
         copy_command(&ss->delay.commands[i], post_command);
 
         return true;

--- a/src/scene_serialization.c
+++ b/src/scene_serialization.c
@@ -202,7 +202,7 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
             }
             else if (c == 'P') { s2 = STATE_PATTERNS; }
             else if (c == 'G') {
-                grid_state = grid_num = grid_count = 0;
+                grid_state = grid_count = 0;
                 s2 = STATE_GRID;
             }
             else {
@@ -210,7 +210,7 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
                 if (script < 0 || script >= EDITABLE_SCRIPT_COUNT) {
                     script = NO_SCRIPT;
                 }
-                else { s2 = STATE_SCRIPT; }
+                s2 = STATE_SCRIPT;
             }
 
             l = 0;
@@ -225,7 +225,9 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
         }
 
         if (s == STATE_SCRIPT) {
-            if (script < 0 || script >= EDITABLE_SCRIPT_COUNT) continue;
+            if (script == NO_SCRIPT || script < 0 ||
+                script >= EDITABLE_SCRIPT_COUNT)
+                continue;
 
             if (c != '\n') {
                 if (p < 32) {
@@ -328,6 +330,12 @@ void deserialize_scene(tt_deserializer_t* stream, scene_state_t* scene,
                 }
             }
             else if (grid_state == 1) {
+                if (c >= '0' && c <= '9') {
+                    grid_num = c - '0';
+                    grid_state = 2;
+                }
+            }
+            else if (grid_state == 2) {
                 if (c >= '0' && c <= '9') {
                     grid_num = grid_num * 10 + c - '0';
                 }

--- a/src/state.h
+++ b/src/state.h
@@ -133,6 +133,8 @@ typedef struct {
     int16_t time[DELAY_SIZE];
     uint8_t origin_script[DELAY_SIZE];
     int16_t origin_i[DELAY_SIZE];
+    int16_t origin_fparam1[DELAY_SIZE];
+    int16_t origin_fparam2[DELAY_SIZE];
     uint8_t count;
 } scene_delay_t;
 

--- a/src/teletype.c
+++ b/src/teletype.c
@@ -375,6 +375,8 @@ void tele_tick(scene_state_t *ss, uint8_t time) {
                 es_variables(&es)->delayed = true;
                 es_variables(&es)->script_number = ss->delay.origin_script[i];
                 es_variables(&es)->i = ss->delay.origin_i[i];
+                es_variables(&es)->fparam1 = ss->delay.origin_fparam1[i];
+                es_variables(&es)->fparam2 = ss->delay.origin_fparam2[i];
 
                 run_script_with_exec_state(ss, &es, DELAY_SCRIPT);
 


### PR DESCRIPTION
#### What does this PR do?

this PR fixes 2 issues:

- grid fader state wasn't deserialized properly after this change: https://github.com/monome/teletype/pull/306
- ops for function parameters `I1` and `I2` (introduced here: https://github.com/monome/teletype/pull/313) were returning 0 if used in a `DEL`

#### How should this be manually tested?

for the serialization bug:

- set grid button and fader states to random values
- save the scene to flash and then to USB
- copy the tt##.txt file to tt##s.txt file
- load the scene from USB, then save it as a new scene
- save the new scene to USB
- compare the files

for the function parameters bug:

```
X 0
$S1 4 12345
BRK
DEL 100: X I1
```
executing the script should set `X` to 12345.

i didn't update changelog/whatsnew since both bugs were introduced in this version.

#### I have,
* [ ] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
