### PR TITLE
fix disting ex looper ops

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - **FIX**: libavr32 update: support CDC grid size detection (e.g. zero), increase HID message buffer
 - **NEW**: new Disting EX ops: `EX.CH`, `EX.#`, `EX.N#`, `EX.NO#`
 - **NEW**: apply VCV Rack compatibility patches, so branches off main can be used in both hardware and software
+- **FIX**: update Disting EX looper ops to work with Disting EX firmware 1.23+
 
 ## v4.0.0
 

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -31,6 +31,7 @@
 - **FIX**: libavr32 update: support CDC grid size detection (e.g. zero), increase HID message buffer
 - **NEW**: new Disting EX ops: `EX.CH`, `EX.#`, `EX.N#`, `EX.NO#`
 - **NEW**: apply VCV Rack compatibility patches, so branches off main can be used in both hardware and software
+- **FIX**: update Disting EX looper ops to work with Disting EX firmware 1.23+
 
 ## v4.0.0
 

--- a/src/ops/disting.c
+++ b/src/ops/disting.c
@@ -799,10 +799,10 @@ static void op_EX_LP_REC_get(const void *NOTUSED(data), scene_state_t *ss,
     s16 loop = cs_pop(cs);
     if (loop < 1 || loop > 4) return;
 
-    send4(0x46, 7, 0, loop);
-    send4(0x46, 56, 0, 0);
-    send4(0x46, 56, 0, 1);
-    send4(0x46, 56, 0, 0);
+    send4(0x6C, 7, 0, loop);
+    send4(0x6C, 55, 0, 0);
+    send4(0x6C, 55, 0, 1);
+    send4(0x6C, 55, 0, 0);
 }
 
 static void op_EX_LP_PLAY_get(const void *NOTUSED(data), scene_state_t *ss,
@@ -810,10 +810,10 @@ static void op_EX_LP_PLAY_get(const void *NOTUSED(data), scene_state_t *ss,
     s16 loop = cs_pop(cs);
     if (loop < 1 || loop > 4) return;
 
-    send4(0x46, 7, 0, loop);
-    send4(0x46, 57, 0, 0);
-    send4(0x46, 57, 0, 1);
-    send4(0x46, 57, 0, 0);
+    send4(0x6C, 7, 0, loop);
+    send4(0x6C, 56, 0, 0);
+    send4(0x6C, 56, 0, 1);
+    send4(0x6C, 56, 0, 0);
 }
 
 static void op_EX_LP_REV_get(const void *NOTUSED(data), scene_state_t *ss,
@@ -821,10 +821,10 @@ static void op_EX_LP_REV_get(const void *NOTUSED(data), scene_state_t *ss,
     s16 loop = cs_pop(cs);
     if (loop < 1 || loop > 4) return;
 
-    send4(0x46, 7, 0, loop);
-    send4(0x46, 58, 0, 0);
-    send4(0x46, 58, 0, 1);
-    send4(0x46, 58, 0, 0);
+    send4(0x6C, 7, 0, loop);
+    send4(0x6C, 57, 0, 0);
+    send4(0x6C, 57, 0, 1);
+    send4(0x6C, 57, 0, 0);
 }
 
 static void op_EX_LP_DOWN_get(const void *NOTUSED(data), scene_state_t *ss,
@@ -832,10 +832,10 @@ static void op_EX_LP_DOWN_get(const void *NOTUSED(data), scene_state_t *ss,
     s16 loop = cs_pop(cs);
     if (loop < 1 || loop > 4) return;
 
-    send4(0x46, 7, 0, loop);
-    send4(0x46, 62, 0, 0);
-    send4(0x46, 62, 0, 1);
-    send4(0x46, 62, 0, 0);
+    send4(0x6C, 7, 0, loop);
+    send4(0x6C, 58, 0, 0);
+    send4(0x6C, 58, 0, 1);
+    send4(0x6C, 58, 0, 0);
 }
 
 static void op_EX_LP_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
@@ -843,7 +843,7 @@ static void op_EX_LP_CLR_get(const void *NOTUSED(data), scene_state_t *ss,
     s16 loop = cs_pop(cs);
     if (loop < 1 || loop > 4) return;
 
-    send4(0x46, 7, 0, loop);
+    send4(0x6C, 7, 0, loop);
     send1(0x58);
 }
 


### PR DESCRIPTION
#### What does this PR do?

fixes the disting ex looper ops that got broken when the disting ex parameter indexes changed in the latest disting ex firmware updates.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

https://llllllll.co/t/teletype-disting-ex-integration/33929/205

#### How should this be manually tested?

by executing the ops

#### I have,
* [x] updated `CHANGELOG.md` and `whats_new.md`
* [ ] updated the documentation
* [ ] updated `help_mode.c` (if applicable)
