### PR TITLE
Combine artifacts into a single release zip

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
   clang-format:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
     - name: Run clang-format
       run: |
         curl -O https://raw.githubusercontent.com/Sarcasm/run-clang-format/master/run-clang-format.py
@@ -21,7 +21,7 @@ jobs:
   run-tests:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install ragel
@@ -33,7 +33,7 @@ jobs:
   build-simulator:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install ragel
@@ -45,7 +45,7 @@ jobs:
   build-firmware:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
       - name: Install ragel
@@ -73,7 +73,7 @@ jobs:
   build-docs:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         with:
           submodules: recursive
           fetch-depth: 0
@@ -96,8 +96,8 @@ jobs:
           path: |
             docs/teletype.pdf
             docs/teletype.html
-            docs/cheatsheet/cheatsheet.pdf
-            docs/cheatsheet/cheatsheet-i2c.pd
+            docs/cheatsheet.pdf
+            docs/cheatsheet-i2c.pdf
   create-release-zip:
     runs-on: ubuntu-latest
     needs: [build-firmware, build-docs]
@@ -107,6 +107,9 @@ jobs:
         with:
           path: release
           merge-multiple: true
+      - uses: actions/checkout@v4
+        with:
+          sparse-checkout: module
       - name: Add firmware update scripts to release 
         run: |
           cp module/update_firmware.command release

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -65,11 +65,11 @@ jobs:
         run: |
           cd module
           make
-      - name: Upload teletype.hex to artifacts
-        uses: actions/upload-artifact@v2
+      - name: Create firmware artifact
+        uses: actions/upload-artifact@v4
         with:
           path: module/teletype.hex
-          name: teletype.hex
+          name: teletype firmware
   build-docs:
     runs-on: ubuntu-latest
     steps:
@@ -89,19 +89,30 @@ jobs:
         run: |
           cd docs
           make
-      - name: Upload docs to artifacts
-        uses: actions/upload-artifact@v2
+      - name: Create documentation artifact
+        uses: actions/upload-artifact@v4
         with:
-          path: docs/teletype.pdf
-          name: teletype.pdf
-      - name: Upload cheatsheet to artifacts
-        uses: actions/upload-artifact@v2
+          name: teletype docs
+          path: |
+            docs/teletype.pdf
+            docs/teletype.html
+            docs/cheatsheet/cheatsheet.pdf
+            docs/cheatsheet/cheatsheet-i2c.pd
+  create-release-zip:
+    runs-on: ubuntu-latest
+    needs: [build-firmware, build-docs]
+    steps:
+      - name: Download artifacts from previous steps
+        uses: actions/download-artifact@v4
         with:
-          path: docs/cheatsheet/cheatsheet.pdf
-          name: cheatsheet.pdf
-      - name: Upload i2c cheatsheet to artifacts
-        uses: actions/upload-artifact@v2
+          path: release
+          merge-multiple: true
+      - name: Add firmware update scripts to release 
+        run: |
+          cp module/update_firmware.command release
+          cp module/flash.sh release
+      - name: Add release zip to artifacts
+        uses: actions/upload-artifact@v4
         with:
-          path: docs/cheatsheet/cheatsheet-i2c.pdf
-          name: cheatsheet-i2c.pdf
-
+          path: release
+          name: teletype.zip

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -94,10 +94,8 @@ jobs:
         with:
           name: teletype (docs only)
           path: |
-            docs/teletype.pdf
-            docs/teletype.html
-            docs/cheatsheet.pdf
-            docs/cheatsheet-i2c.pdf
+            docs/*.pdf
+            docs/*.html
   create-release-zip:
     runs-on: ubuntu-latest
     needs: [build-firmware, build-docs]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -69,7 +69,7 @@ jobs:
         uses: actions/upload-artifact@v4
         with:
           path: module/teletype.hex
-          name: teletype firmware
+          name: teletype (firmware only)
   build-docs:
     runs-on: ubuntu-latest
     steps:
@@ -92,7 +92,7 @@ jobs:
       - name: Create documentation artifact
         uses: actions/upload-artifact@v4
         with:
-          name: teletype docs
+          name: teletype (docs only)
           path: |
             docs/teletype.pdf
             docs/teletype.html
@@ -102,20 +102,21 @@ jobs:
     runs-on: ubuntu-latest
     needs: [build-firmware, build-docs]
     steps:
-      - name: Download artifacts from previous steps
-        uses: actions/download-artifact@v4
-        with:
-          path: release
-          merge-multiple: true
       - uses: actions/checkout@v4
         with:
           sparse-checkout: module
       - name: Add firmware update scripts to release 
         run: |
+          mkdir release
           cp module/update_firmware.command release
           cp module/flash.sh release
+      - name: Download artifacts from previous steps
+        uses: actions/download-artifact@v4
+        with:
+          path: release
+          merge-multiple: true
       - name: Add release zip to artifacts
         uses: actions/upload-artifact@v4
         with:
           path: release
-          name: teletype.zip
+          name: teletype

--- a/.gitignore
+++ b/.gitignore
@@ -50,8 +50,8 @@ __pycache__/
 /simulator/tt
 /module/gitversion.c
 /tests/tests
-/docs/teletype.pdf
-/docs/teletype.html
+/docs/*.pdf
+/docs/*.html
 /docs/cheatsheet/*
 !/docs/cheatsheet/cs-common.tex
 /docs/testServe/

--- a/docs/Makefile
+++ b/docs/Makefile
@@ -1,6 +1,6 @@
 .PHONY: build clean
 
-build: teletype.pdf teletype.html cheatsheet/cheatsheet.pdf cheatsheet/cheatsheet-i2c.pdf
+build: teletype.pdf teletype.html cheatsheet.pdf cheatsheet-i2c.pdf
 
 clean:
 	rm -f teletype.pdf && \
@@ -24,5 +24,8 @@ cheatsheet/cheatsheet-%.tex: $(wildcard ops/*.toml) ../utils/cheatsheet.py
 cheatsheet/cheatsheet-%.pdf: cheatsheet/cs-common.tex cheatsheet/cheatsheet-%.tex
 	cd cheatsheet && latexmk -xelatex cs-common.tex -jobname=cheatsheet-$*
 
-cheatsheet/cheatsheet.pdf: cheatsheet/cheatsheet-core.pdf
-	cd cheatsheet && cp cheatsheet-core.pdf cheatsheet.pdf
+cheatsheet.pdf: cheatsheet/cheatsheet-core.pdf
+	cp cheatsheet/cheatsheet-core.pdf cheatsheet.pdf
+
+cheatsheet-i2c.pdf: cheatsheet/cheatsheet-i2c.pdf
+	cp cheatsheet/cheatsheet-i2c.pdf .


### PR DESCRIPTION
#### What does this PR do?
Further tweaks the artifact production process in Actions to include the HTML docs and also combine everything into a release .zip with the firmware update scripts.

#### Provide links to any related discussion on [lines](https://llllllll.co/).

#### How should this be manually tested?

#### Any background context you want to provide?

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* n/a updated `CHANGELOG.md` and `whats_new.md`
* n/a updated the documentation
* n/a updated `help_mode.c` (if applicable)
