### PR TITLE
Fix potential crash in help mode reverse search

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## v5.0.x:
+
+- **FIX**: fix risk of crash/corruption in help mode reverse search
+
 ## v5.0.0
 
 - **FIX**: fix off-by-one error in `P.ROT` understanding of pattern length

--- a/docs/whats_new.md
+++ b/docs/whats_new.md
@@ -1,5 +1,9 @@
 # Updates
 
+## v5.0.x
+
+- **FIX**: fix risk of crash/corruption in help mode reverse search
+
 ## v5.0.0
 
 - **FIX**: fix off-by-one error in `P.ROT` understanding of pattern length

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -1692,6 +1692,9 @@ bool text_search_forward(search_state_t* state, const char* needle,
 bool text_search_reverse(search_state_t* state, const char* needle,
                          const char** haystack, int haystack_len) {
     const int needle_len = strlen(needle);
+    if (state->line >= haystack_len) {
+        state->line = haystack_len - 1;
+    }
     for (; state->line >= 0; state->line--) {
         const int haystack_line_len = strlen(haystack[state->line]);
         for (state->ch = haystack_line_len - needle_len; state->ch >= 0;


### PR DESCRIPTION
#### What does this PR do?

It's possible for help mode reverse search to index beyond the bounds of a page. On hardware, this is likely not a hard crash, but it could lead to unexpected behavior. On VCV Rack hitting this results in a crash (see https://github.com/Dewb/monome-rack/issues/206).

#### How should this be manually tested?

See steps to reproduce in https://github.com/Dewb/monome-rack/issues/206

#### I have,
* [X] updated `CHANGELOG.md` and `whats_new.md`
* [X] updated the documentation
* [X] updated `help_mode.c` (if applicable)
