### PR TITLE
satisfy CI clang-format

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -32,7 +32,7 @@ teletype.zip: clean-zip
 		docs/cheatsheet/cheatsheet.pdf
 
 format:
-	git-clang-format -f --style=file
+	git-clang-format -f --style=file main
 
 format-all:
 	find . -type f -name "*.c" -o -name "*.h" | xargs clang-format -style=file -i

--- a/module/help_mode.c
+++ b/module/help_mode.c
@@ -1692,9 +1692,7 @@ bool text_search_forward(search_state_t* state, const char* needle,
 bool text_search_reverse(search_state_t* state, const char* needle,
                          const char** haystack, int haystack_len) {
     const int needle_len = strlen(needle);
-    if (state->line >= haystack_len) {
-        state->line = haystack_len - 1;
-    }
+    if (state->line >= haystack_len) { state->line = haystack_len - 1; }
     for (; state->line >= 0; state->line--) {
         const int haystack_line_len = strlen(haystack[state->line]);
         for (state->ch = haystack_line_len - needle_len; state->ch >= 0;


### PR DESCRIPTION
#### What does this PR do?

fixes format warning in CI introduced in #336

#### Provide links to any related discussion on [lines](https://llllllll.co/).

n/a

#### How should this be manually tested?

n/a

#### Any background context you want to provide?

Looks like local clang-format results and CI results are not consistent, c-f didn't complain for me locally. (Apple clang 15.0.0, latest git clang-format integration via homebrew.)

#### If the related Github issues aren't referenced in your commits, please link to them here.

#### I have,
* (n/a) updated `CHANGELOG.md` and `whats_new.md`
* (n/a) updated the documentation
* (n/a) updated `help_mode.c` (if applicable)
